### PR TITLE
Use bigint instead of BigInt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Release 0.3.0 (in progress)
+
+**Features**:
+
+* Use `bigint` instead of `BigInt`, [PR-13](https://github.com/reduct-storage/reduct-js/pull/13)
+
 ## Release 0.2.0 (2022-04-16)
 
 **Features**:

--- a/src/BucketInfo.ts
+++ b/src/BucketInfo.ts
@@ -10,22 +10,22 @@ export class BucketInfo {
     /**
      * Number of entries in the bucket
      */
-    readonly entryCount: BigInt = 0n;
+    readonly entryCount: bigint = 0n;
 
     /**
      * Size of stored data in the bucket in bytes
      */
-    readonly size: BigInt = 0n;
+    readonly size: bigint = 0n;
 
     /**
      * Unix timestamp of the oldest record in microseconds
      */
-    readonly oldestRecord: BigInt = 0n;
+    readonly oldestRecord: bigint = 0n;
 
     /**
      * Unix timestamp of the latest record in microseconds
      */
-    readonly latestRecord: BigInt = 0n;
+    readonly latestRecord: bigint = 0n;
 
 
     static parse(bucket: Original): BucketInfo {

--- a/src/BucketSettings.ts
+++ b/src/BucketSettings.ts
@@ -7,9 +7,9 @@ export enum QuotaType {
  *  Represents bucket settings
  */
 export class BucketSettings {
-    readonly maxBlockSize?: BigInt;
+    readonly maxBlockSize?: bigint;
     readonly quotaType?: QuotaType;
-    readonly quotaSize?: BigInt;
+    readonly quotaSize?: bigint;
 
     static parse(data: Original): BucketSettings {
         const {max_block_size, quota_type, quota_size} = data;

--- a/src/EntryInfo.ts
+++ b/src/EntryInfo.ts
@@ -10,12 +10,12 @@ export class EntryInfo {
     /**
      * Number of blocks
      */
-    readonly blockCount: BigInt = 0n;
+    readonly blockCount: bigint = 0n;
 
     /**
      * Number of records
      */
-    readonly recordCount: BigInt = 0n;
+    readonly recordCount: bigint = 0n;
 
     /**
      * Size of stored data in the bucket in bytes
@@ -25,12 +25,12 @@ export class EntryInfo {
     /**
      * Unix timestamp of the oldest record in microseconds
      */
-    readonly oldestRecord: BigInt = 0n;
+    readonly oldestRecord: bigint = 0n;
 
     /**
      * Unix timestamp of the latest record in microseconds
      */
-    readonly latestRecord: BigInt = 0n;
+    readonly latestRecord: bigint = 0n;
 
     static parse(bucket: Original): EntryInfo {
         return {

--- a/src/ServerInfo.ts
+++ b/src/ServerInfo.ts
@@ -10,27 +10,27 @@ export class ServerInfo {
     /**
      * Number of buckets
      */
-    readonly bucketCount: BigInt = 0n;
+    readonly bucketCount: bigint = 0n;
 
     /**
      * Stored data in bytes
      */
-    readonly usage: BigInt = 0n;
+    readonly usage: bigint = 0n;
 
     /**
      * Server uptime in seconds
      */
-    readonly uptime: BigInt = 0n;
+    readonly uptime: bigint = 0n;
 
     /**
      * Unix timestamp of the oldest record in microseconds
      */
-    readonly oldestRecord: BigInt = 0n;
+    readonly oldestRecord: bigint = 0n;
 
     /**
      * Unix timestamp of the latest record in microseconds
      */
-    readonly latestRecord: BigInt = 0n;
+    readonly latestRecord: bigint = 0n;
 
     static parse(data: Original): ServerInfo {
         return {


### PR DESCRIPTION
The client code should be easier. When we use `BigInt` we should call `valueOf()` to get the primitive. 