### PR TITLE
[#36] Support Reduct Storage API v0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added:
+
+- Support Reduct Storage API v0.7, [PR-37](https://github.com/reduct-storage/reduct-js/pull/37)
+
 ## [0.5.1] - 2002-07-17
 
 ### Fixed:
@@ -61,16 +67,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * QuotaType in index.js, [PR-9](https://github.com/reduct-storage/reduct-js/pull/9)
 
-##  [0.1.0]  - 2022-04-14
+## [0.1.0]  - 2022-04-14
 
 - Initial release
 
-
 [Unreleased]: https://github.com/reduct-storage/reduct-js/compare/v0.5.1...HEAD
+
 [0.5.1]: https://github.com/reduct-storage/reduct-js/compare/v0.5.0...v0.5.1
+
 [0.5.0]: https://github.com/reduct-storage/reduct-js/compare/v0.4.1...v0.5.0
+
 [0.4.1]: https://github.com/reduct-storage/reduct-js/compare/v0.4.0...v0.4.1
+
 [0.4.0]: https://github.com/reduct-storage/reduct-js/compare/v0.3.0...v0.4.0
+
 [0.3.0]: https://github.com/reduct-storage/reduct-js/compare/v0.2.0...v0.3.0
+
 [0.2.0]: https://github.com/reduct-storage/reduct-js/compare/v0.1.0...v0.2.0
+
 [0.1.0]: https://github.com/reduct-storage/reduct-js/compare/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ Asynchronous HTTP client for [Reduct Storage](https://reduct-storage.dev) writte
 ## Features
 
 * Promise based
-* Support Reduct Storage API v0.5
+* Support Reduct Storage API v0.7
 * Token authentication
 
 ## Getting Started
 
-Read [here](https://docs.reduct-storage.dev/#start-with-docker), how to run Reduct Storage. 
+Read [here](https://docs.reduct-storage.dev/#start-with-docker), how to run Reduct Storage.
 Then install the package:
 
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@typescript-eslint/parser": "^5.19.0",
         "babel-jest": "^27.5.1",
         "eslint": "^8.13.0",
+        "it-all": "^1.0.6",
         "jest": "^27.5.1",
         "jest-config": "^27.5.1",
         "jsdoc": "^3.6.10",
@@ -5252,6 +5253,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/it-all": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
+      "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A==",
+      "dev": true
     },
     "node_modules/jest": {
       "version": "27.5.1",
@@ -13033,6 +13040,12 @@
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
       }
+    },
+    "it-all": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
+      "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A==",
+      "dev": true
     },
     "jest": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@typescript-eslint/parser": "^5.19.0",
     "babel-jest": "^27.5.1",
     "eslint": "^8.13.0",
+    "it-all": "^1.0.6",
     "jest": "^27.5.1",
     "jest-config": "^27.5.1",
     "jsdoc": "^3.6.10",

--- a/src/Record.ts
+++ b/src/Record.ts
@@ -1,0 +1,32 @@
+import Stream from "stream";
+
+/**
+ * Represents a record in an entry
+ */
+export class Record {
+    public readonly time: bigint;
+    public readonly size: bigint;
+    public readonly stream: Stream;
+
+    /**
+     * Constructor which should be call from Bucket
+     * @internal
+     */
+    public constructor(time: bigint, size: bigint, stream: Stream) {
+        this.time = time;
+        this.size = size;
+        this.stream = stream;
+    }
+
+    /**
+     * Read content of record
+     */
+    public async read(): Promise<Buffer> {
+        const chunks: Buffer[] = [];
+        return new Promise((resolve, reject) => {
+            this.stream.on("data", (chunk: Buffer) => chunks.push(chunk));
+            this.stream.on("error", (err: Error) => reject(err));
+            this.stream.on("end", () => resolve(Buffer.concat(chunks)));
+        });
+    }
+}

--- a/test/Bucket.test.ts
+++ b/test/Bucket.test.ts
@@ -1,12 +1,18 @@
+import crypto from "crypto";
+import {Buffer} from "buffer";
+import md5 from "md5";
+import * as Stream from "stream";
+// @ts-ignore
+import all from "it-all";
+
 import {Client} from "../src/Client";
 import {Bucket} from "../src/Bucket";
 import {cleanStorage, makeClient} from "./Helpers";
 import {BucketInfo} from "../src/BucketInfo";
 import {QuotaType} from "../src/BucketSettings";
-import crypto from "crypto";
-import {Buffer} from "buffer";
-import md5 from "md5";
-import * as Stream from "stream";
+
+
+import {Record} from "../src/Record";
 
 describe("Bucket", () => {
     const client: Client = makeClient();
@@ -37,7 +43,7 @@ describe("Bucket", () => {
     it("should get/set settings", async () => {
         const bucket: Bucket = await client.getBucket("bucket");
         await expect(bucket.getSettings()).resolves.toEqual({
-            maxBlockSize: 67108864n,
+            maxBlockSize: 64000000n,
             maxBlockRecords: 1024n,
             quotaSize: 0n,
             quotaType: QuotaType.NONE
@@ -113,6 +119,33 @@ describe("Bucket", () => {
 
         expect(actual.length).toEqual(bigBlob.length);
         expect(md5(actual)).toEqual(md5(bigBlob));
+    });
+
+    it("should query records", async () => {
+        const bucket: Bucket = await client.getBucket("bucket");
+        const records: Record[] = await all(bucket.query("entry-2"));
+
+        expect(records.length).toEqual(2);
+        expect(records[0].time).toEqual(2_000_000n);
+        expect(records[0].size).toEqual(9n);
+        expect(await records[0].read()).toEqual(Buffer.from("somedata2", "ascii"));
+
+        expect(records[1].time).toEqual(3_000_000n);
+        expect(records[1].size).toEqual(9n);
+        expect(await records[1].read()).toEqual(Buffer.from("somedata3", "ascii"));
+    });
+
+    it("should query records with parameters", async () => {
+        const bucket: Bucket = await client.getBucket("bucket");
+        let records: Record[] = await all(bucket.query("entry-2", 3_000_000n));
+        expect(records.length).toEqual(1);
+
+        records = await all(bucket.query("entry-2", 2_000_000n, 2_000_001n));
+        expect(records.length).toEqual(1);
+
+
+        await expect(all(bucket.query("entry-2", undefined, undefined, 0)))
+            .rejects.toHaveProperty("status", 404);
     });
 
 });

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -56,7 +56,7 @@ describe("Client", () => {
         expect(info.latestRecord).toEqual(2000_000n);
 
         expect(info.defaults.bucket).toEqual({
-            maxBlockSize: 67108864n,
+            maxBlockSize: 64000000n,
             maxBlockRecords: 1024n,
             quotaSize: 0n,
             quotaType: QuotaType.NONE,
@@ -91,7 +91,7 @@ describe("Client", () => {
     it("should create a bucket if default settings", async () => {
         const bucket = await client.createBucket("bucket");
         await expect(bucket.getSettings()).resolves.toEqual({
-            maxBlockSize: 67108864n,
+            maxBlockSize: 64000000n,
             maxBlockRecords: 1024n,
             quotaSize: 0n,
             quotaType: QuotaType.NONE
@@ -105,7 +105,7 @@ describe("Client", () => {
             maxBlockRecords: 1029n
         });
         await expect(bucket.getSettings()).resolves.toEqual({
-            maxBlockSize: 67108864n,
+            maxBlockSize: 64000000n,
             maxBlockRecords: 1029n,
             quotaSize: 1024n,
             quotaType: QuotaType.FIFO


### PR DESCRIPTION
Closes #36 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature 

### What is the current behavior?

We supported v0.6

### What is the new behavior?

We support the API v0.7 with querying data, which is implemented as `Bucket.query` method

### Does this PR introduce a breaking change?** 

It doesn't,  but `Bucket.list` is deprecated now.

### Other information:
