### PR TITLE
Remove hash for api token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support Reduct Storage API v0.7, [PR-37](https://github.com/reduct-storage/reduct-js/pull/37)
 
+### Removed:
+
+- Hash for API token and `sjcl` from dependencies [PR-38](https://github.com/reduct-storage/reduct-js/pull/38)
+
 ## [0.5.1] - 2002-07-17
 
 ### Fixed:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
-        "axios": "^0.27.2",
-        "sjcl": "^1.0.8"
+        "axios": "^0.27.2"
       },
       "devDependencies": {
         "@babel/core": "^7.17.9",
@@ -8211,14 +8210,6 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true
     },
-    "node_modules/sjcl": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/sjcl/-/sjcl-1.0.8.tgz",
-      "integrity": "sha512-LzIjEQ0S0DpIgnxMEayM1rq9aGwGRG4OnZhCdjx7glTaJtf4zRfpg87ImfjSJjoW9vKpagd82McDOwbRT5kQKQ==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -15272,11 +15263,6 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true
-    },
-    "sjcl": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/sjcl/-/sjcl-1.0.8.tgz",
-      "integrity": "sha512-LzIjEQ0S0DpIgnxMEayM1rq9aGwGRG4OnZhCdjx7glTaJtf4zRfpg87ImfjSJjoW9vKpagd82McDOwbRT5kQKQ=="
     },
     "slash": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "typescript": "^4.6.3"
   },
   "dependencies": {
-    "axios": "^0.27.2",
-    "sjcl": "^1.0.8"
+    "axios": "^0.27.2"
   }
 }

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -10,7 +10,6 @@ import {APIError} from "./APIError";
 import {BucketInfo} from "./BucketInfo";
 import {BucketSettings} from "./BucketSettings";
 import {Bucket} from "./Bucket";
-import {hash, codec} from "sjcl";
 
 /**
  * Options
@@ -38,15 +37,13 @@ export class Client {
             (response: AxiosResponse) => response,
             async (error: AxiosError) => {
                 if (error.config && error.response && error.response.status == 401 && options.apiToken) {
-                    const hashedToken = hash.sha256.hash(options.apiToken);
-
                     try {
                         // Use axios instead the instance not to cycle with 401 error
                         const resp: AxiosResponse = await axios.post("/auth/refresh", {}, {
                             baseURL: url,
                             timeout: options.timeout,
                             headers: {
-                                "Authorization": `Bearer ${codec.hex.fromBits(hashedToken)}`
+                                "Authorization": `Bearer ${options.apiToken}`
                             }
                         });
 


### PR DESCRIPTION
Refs  reduct-storage/reduct-storage#131

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Change

### What is the current behavior?

We're hashing the API token with the `sjcl` library.

### What is the new behavior?

Since Reduct Storage v0.7 it is not needed, and we can get rid of `sjcl`.


### Does this PR introduce a breaking change?** 

Nope

### Other information:
