### PR TITLE
Support Reduct Storage API v1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ jobs:
   tests:
     needs: build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        token: ["", "TOKEN"]
+
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v2
@@ -35,33 +39,14 @@ jobs:
           name: image
           path: /tmp/
       - name: Run Reduct Storage
-        run: docker run -p 8383:8383 -v ${PWD}/data:/data -d ghcr.io/reduct-storage/reduct-storage:latest
+        run: docker run -p 8383:8383 -v ${PWD}/data:/data --env RS_API_TOKEN=${{ matrix.token }} -d ghcr.io/reduct-storage/reduct-storage:main
 
       - name: Load image with tests
         run: |
           docker load --input /tmp/image.tar
           docker image ls -a
       - name: Run tests
-        run: docker run --network=host ${{github.repository}} npm test
-
-  tests_with_token:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: image
-          path: /tmp/
-      - name: Run Reduct Storage
-        run: docker run -p 8383:8383 -v ${PWD}/data:/data --env RS_API_TOKEN=ABC -d ghcr.io/reduct-storage/reduct-storage:latest
-
-      - name: Load image with tests
-        run: |
-          docker load --input /tmp/image.tar
-          docker image ls -a
-      - name: Run tests
-        run: docker run --network=host --env RS_API_TOKEN=ABC ${{github.repository}} npm test
+        run: docker run --network=host --env RS_API_TOKEN=${{ matrix.token }} ${{github.repository}} npm test
 
   lint:
     needs: build
@@ -72,8 +57,6 @@ jobs:
         with:
           name: image
           path: /tmp/
-      - name: Run Reduct Storage
-        run: docker run -p 8383:8383 -v ${PWD}/data:/data -d ghcr.io/reduct-storage/reduct-storage:latest
 
       - name: Load image with tests
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added:
+
+- Support Reduct Storage API v1.0, [PR-43](https://github.com/reduct-storage/reduct-js/pull/43)
+
+### Removed:
+
+- `Bucket.list` method, [PR-43](https://github.com/reduct-storage/reduct-js/pull/43)
+
 ## [0.7.0] - 2022-08-27
 
 ### Added:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Asynchronous HTTP client for [Reduct Storage](https://reduct-storage.dev) writte
 ## Features
 
 * Promise based
-* Support Reduct Storage API v0.8
+* Support Reduct Storage API v1.0
 * Token authentication
 
 ## Getting Started

--- a/src/Bucket.ts
+++ b/src/Bucket.ts
@@ -127,23 +127,6 @@ export class Bucket {
     }
 
     /**
-     * List records for a time period
-     * @param entry {string} name of the entry
-     * @param start {BigInt} start point of the time period
-     * @param stop {BigInt} stop point of the time period
-     * @deprecated since version 0.6 use query instead
-     */
-    async list(entry: string, start: bigint, stop: bigint): Promise<{ size: bigint, timestamp: bigint }[]> {
-        const {data} = await this.httpClient.get(`/b/${this.name}/${entry}/list?start=${start}&stop=${stop}`);
-        return data.records.map((rec: any) => {
-            return {
-                size: BigInt(rec.size),
-                timestamp: BigInt(rec.ts)
-            };
-        });
-    }
-
-    /**
      * Query records for a time interval as generator
      * @param entry entry name
      * @param entry {string} name of the entry

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -29,7 +29,7 @@ export class Client {
      */
     constructor(url: string, options: ClientOptions = {}) {
         this.httpClient = axios.create({
-            baseURL: url,
+            baseURL: `${url}/api/v1`,
             timeout: options.timeout,
             headers: {
                 "Authorization": `Bearer ${options.apiToken}`

--- a/test/Bucket.test.ts
+++ b/test/Bucket.test.ts
@@ -93,14 +93,6 @@ describe("Bucket", () => {
         await (expect(bucket.read("entry-2", 10000_000n))).rejects.toMatchObject({status: 404});
     });
 
-    it("should list record in a entry", async () => {
-        const bucket: Bucket = await client.getBucket("bucket");
-        await (expect(bucket.list("entry-2", 0n, 4000_000n))).resolves.toEqual([
-            {size: 9n, timestamp: 2000_000n},
-            {size: 9n, timestamp: 3000_000n}
-        ]);
-    });
-
     it("should write and read a big blob as streams", async () => {
         const bigBlob = crypto.randomBytes(2 ** 20);
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Update

### What is the current behavior?

The SDK supports API v0.8

### What is the new behavior?

The SDK supports API v1.0


### Does this PR introduce a breaking change?

Yes. API v0.8 and API v1.0 aren't compatible. The `Bucket.list` method was removed

### Other information:
