### PR TITLE
Refactor read and write operations with records

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
 -   repo: local
     hooks:
     - id: tsc
-      types_or: [ javascript, jsx, ts, tsx ]
+      types_or: [ jsx, ts, tsx ]
       name: tsc
       entry: npm
       language: node
@@ -23,7 +23,7 @@ repos:
 -   repo: local
     hooks:
     - id: eslint
-      types_or: [ javascript, jsx, ts, tsx ]
+      types_or: [ ts, tsx ]
       name: eslint
       entry: npm
       language: node

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed:
 
 - `Bucket.list` method, [PR-43](https://github.com/reduct-storage/reduct-js/pull/43)
+- `Bucket.readStream`, `Bucket.writeStream` methods, [PR-44](https://github.com/reduct-storage/reduct-js/pull/44)
+
+### Changes:
+
+- `Bucket.read`, `Bucket.write` methods, [PR-44](https://github.com/reduct-storage/reduct-js/pull/44)
 
 ## [0.7.0] - 2022-08-27
 

--- a/README.md
+++ b/README.md
@@ -24,20 +24,24 @@ npm i reduct-js
 And run this example:
 
 ```js
-const {Client} = require("reduct-js")
+const {Client} = require("../lib/cjs/index.js");
+
+const client = new Client("http://127.0.0.1:8383");
 
 const main = async () => {
-  const client = new Client("https://play.reduct-storage.dev", {apiToken: "reduct"});
+    const bucket = await client.getOrCreateBucket("bucket");
 
-  const bucket = await client.getOrCreateBucket("bucket");
+    const timestamp = Date.now() * 1000;
+    let record = await bucket.beginWrite("entry-1", timestamp);
+    await record.write("Hello, World!");
 
-  const timestamp = Date.now() * 1000;
-  await bucket.write("entry-1", "Hello, World!", timestamp);
-  console.log(await bucket.read("entry-1", timestamp));
+    record = await bucket.beginRead("entry-1", timestamp);
+    console.log((await record.read()).toString());
 };
 
 main()
-  .then(() => console.log("done"))
-  .catch((err) => console.error("oops: ", err));
+    .then(() => console.log("done"))
+    .catch((err) => console.error("oops: ", err));
+
 
 ```

--- a/examples/HelloWorld.js
+++ b/examples/HelloWorld.js
@@ -1,15 +1,18 @@
 const {Client} = require("../lib/cjs/index.js");
 
-const main = async () => {
-  const client = new Client("http://127.0.0.1:8383");
+const client = new Client("http://127.0.0.1:8383");
 
-  const bucket = await client.getOrCreateBucket("bucket");
-  
-  const timestamp = Date.now() * 1000;
-  await bucket.write("entry-1", "Hello, World!", timestamp);
-  console.log(await bucket.read("entry-1", timestamp));
+const main = async () => {
+    const bucket = await client.getOrCreateBucket("bucket");
+
+    const timestamp = Date.now() * 1000;
+    let record = await bucket.beginWrite("entry-1", timestamp);
+    await record.write("Hello, World!");
+
+    record = await bucket.beginRead("entry-1", timestamp);
+    console.log(await record.readAsString());
 };
 
 main()
-  .then(() => console.log("done"))
-  .catch((err) => console.error("oops: ", err));
+    .then(() => console.log("done"))
+    .catch((err) => console.error("oops: ", err));

--- a/src/Record.ts
+++ b/src/Record.ts
@@ -1,9 +1,11 @@
 import Stream from "stream";
+// @ts-ignore`
+import {AxiosInstance} from "axios";
 
 /**
- * Represents a record in an entry
+ * Represents a record in an entry for reading
  */
-export class Record {
+export class ReadableRecord {
     public readonly time: bigint;
     public readonly size: bigint;
     public readonly last: boolean;
@@ -30,5 +32,51 @@ export class Record {
             this.stream.on("error", (err: Error) => reject(err));
             this.stream.on("end", () => resolve(Buffer.concat(chunks)));
         });
+    }
+
+    /**
+     * Read content of record and convert to string
+     */
+    public async readAsString(): Promise<string> {
+        return (await this.read()).toString();
+    }
+}
+
+/**
+ * Represents a record in an entry for writing
+ */
+export class WritableRecord {
+    public readonly time: bigint;
+    private readonly bucketName: string;
+    private readonly entryName: string;
+    private readonly httpClient: AxiosInstance;
+
+    /**
+     * Constructor for stream
+     * @internal
+     */
+    public constructor(bucketName: string, entryName: string, time: bigint, httpClient: AxiosInstance) {
+        this.bucketName = bucketName;
+        this.entryName = entryName;
+        this.time = time;
+        this.httpClient = httpClient;
+    }
+
+    /**
+     * Write data to record asynchronously
+     * @param data stream of buffer with data
+     * @param size size of data in bytes (only for streams)
+     */
+    public async write(data: Buffer | string | Stream, size?: bigint | number): Promise<void> {
+        let contentLength = size || 0;
+        if (!(data instanceof Stream)) {
+            contentLength = data.length;
+        }
+
+        const {bucketName, entryName, time} = this;
+        await this.httpClient.post(`/b/${bucketName}/${entryName}?ts=${time}`, data, {
+                headers: {"content-length": contentLength.toString()}
+            }
+        );
     }
 }

--- a/src/Record.ts
+++ b/src/Record.ts
@@ -6,15 +6,17 @@ import Stream from "stream";
 export class Record {
     public readonly time: bigint;
     public readonly size: bigint;
+    public readonly last: boolean;
     public readonly stream: Stream;
 
     /**
      * Constructor which should be call from Bucket
      * @internal
      */
-    public constructor(time: bigint, size: bigint, stream: Stream) {
+    public constructor(time: bigint, size: bigint, last: boolean, stream: Stream) {
         this.time = time;
         this.size = size;
+        this.last = last;
         this.stream = stream;
     }
 

--- a/test/Bucket.test.ts
+++ b/test/Bucket.test.ts
@@ -80,12 +80,18 @@ describe("Bucket", () => {
 
     it("should read latest record", async () => {
         const bucket: Bucket = await client.getBucket("bucket");
-        await (expect(bucket.read("entry-2"))).resolves.toEqual(Buffer.from("somedata3", "ascii"));
+        const record = await bucket.read("entry-2");
+
+        expect(record).toMatchObject({size: 9n, time: 3000000n, last: true});
+        expect(await record.read()).toEqual(Buffer.from("somedata3", "ascii"));
     });
 
     it("should read a record by timestamp", async () => {
         const bucket: Bucket = await client.getBucket("bucket");
-        await (expect(bucket.read("entry-2", 2000_000n))).resolves.toEqual(Buffer.from("somedata2", "ascii"));
+        const record = await bucket.read("entry-2", 2000000n);
+
+        expect(record).toMatchObject({size: 9n, time: 2000000n, last: true});
+        expect(await record.read()).toEqual(Buffer.from("somedata2", "ascii"));
     });
 
     it("should read a record with error if timestamp is wrong", async () => {
@@ -99,7 +105,7 @@ describe("Bucket", () => {
         const bucket: Bucket = await client.getBucket("bucket");
         await bucket.writeStream("big-blob", Stream.Readable.from(bigBlob), bigBlob.length);
 
-        const readStream: Stream = await bucket.readStream("big-blob");
+        const readStream: Stream = (await bucket.read("big-blob")).stream;
 
         const actual: Buffer = await new Promise((resolve, reject) => {
             const chunks: Buffer[] = [];

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -43,8 +43,11 @@ describe("Client", () => {
     it("should get information about the server", async () => {
         await client.createBucket("bucket_1");
         const bucket = await client.createBucket("bucket_2");
-        await bucket.write("entry", "somedata", 1000_000n);
-        await bucket.write("entry", "somedata", 2000_000n);
+        let rec = await bucket.beginWrite("entry", 1000_000n);
+        await rec.write("somedata");
+
+        rec = await bucket.beginWrite("entry", 2000_000n);
+        await rec.write("somedata");
 
         const info: ServerInfo = await client.getInfo();
         expect(info.version >= "0.8.0").toBeTruthy();


### PR DESCRIPTION
Closes #42

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Refactoring

### What is the current behavior?

See #42 

### What is the new behavior?

```js
    const bucket = await client.getOrCreateBucket("bucket");

    const timestamp = Date.now() * 1000;
    let record = await bucket.beginWrite("entry-1", timestamp);
    await record.write("Hello, World!");

    record = await bucket.beginRead("entry-1", timestamp);
    console.log(await record.readAsString());
```

### Does this PR introduce a breaking change?

Yes

### Other information:
