### PR TITLE
Fix broken replication api in v1.17 version

### DIFF
--- a/src/messages/ReplicationSettings.ts
+++ b/src/messages/ReplicationSettings.ts
@@ -6,7 +6,7 @@ export class OriginalReplicationSettings {
   src_bucket = "";
   dst_bucket = "";
   dst_host = "";
-  dst_token = "";
+  dst_token?: string;
   entries: string[] = [];
   include?: Record<string, string>;
   exclude?: Record<string, string>;
@@ -37,7 +37,7 @@ export class ReplicationSettings {
   /**
    * Destination token. Must have write access to the destination bucket.
    */
-  readonly dstToken: string = "";
+  readonly dstToken?: string;
 
   /**
    * List of entries to replicate. If empty, all entries are replicated. Wildcards are supported.

--- a/test/Replication.test.ts
+++ b/test/Replication.test.ts
@@ -9,7 +9,6 @@ describe("Replication", () => {
     srcBucket: "test-bucket-1",
     dstBucket: "test-bucket-2",
     dstHost: "http://localhost:8383",
-    dstToken: "***", // it is not possible to get token from the server
     entries: [],
     include: {},
     exclude: {},
@@ -35,7 +34,7 @@ describe("Replication", () => {
     expect(replications).toHaveLength(0);
   });
 
-  it_api("1.8")("should create a replication", async () => {
+  it_api("1.17")("should create a replication", async () => {
     await client.createReplication("test-replication", settings);
 
     const replications = await client.getReplicationList();
@@ -65,14 +64,13 @@ describe("Replication", () => {
     expect(replications).toHaveLength(0);
   });
 
-  it_api("1.14")("should update a replication", async () => {
+  it_api("1.17")("should update a replication", async () => {
     await client.createReplication("test-replication", settings);
 
     const newSettings = {
       srcBucket: "test-bucket-1",
       dstBucket: "test-bucket-2",
       dstHost: "http://localhost:8383",
-      dstToken: "***",
       entries: ["entry-1", "entry-2"],
       when: { "&label": { $eq: "value" } },
     };


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

The v1.17 API allows the token in ReplicationSettings be empty. 

### Related issues

https://github.com/reductstore/reductstore/pull/962

### Does this PR introduce a breaking change?

Yes

### Other information:
