### PR TITLE
Add sticky-session cookie support in Node.js client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `Bucket.removeAttachments` for numeric attachment keys by casting `&key` to string in the filter condition, [PR-145](https://github.com/reductstore/reduct-js/pull/145)
 - Fix `Bucket.removeAttachments` for attachment keys prefixed with `$` by escaping them in queries, [PR-147](https://github.com/reductstore/reduct-js/pull/147)
 - Keep BatchV2 query loop running on empty batch responses, [PR-148](https://github.com/reductstore/reduct-js/pull/148)
+- Enable sticky sessions by default in Node.js while keeping explicit opt-out support, [PR-151](https://github.com/reductstore/reduct-js/pull/151)
 
 ## 1.18.1 - 2026-02-05
 

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -31,7 +31,7 @@ export type ClientOptions = {
   timeout?: number; // communication timeout
   verifySSL?: boolean; // verify SSL certificate
   keepAlive?: boolean; // keep HTTP connections alive (Node.js)
-  stickySessions?: boolean; // persist/replay cookies for sticky sessions
+  stickySessions?: boolean; // persist/replay cookies for sticky sessions (enabled by default in Node.js)
   cookieJar?: CookieJar; // optional custom cookie jar for sticky sessions
 };
 

--- a/src/http/HttpClient.ts
+++ b/src/http/HttpClient.ts
@@ -97,7 +97,7 @@ export class HttpClient {
     this.baseURL = `${url}/api/v1`;
     this.timeout = options.timeout;
     this.keepAlive = options.keepAlive ?? false;
-    this.stickySessions = options.stickySessions ?? false;
+    this.stickySessions = options.stickySessions ?? !isBrowser;
     this.cookieJar = this.stickySessions
       ? (options.cookieJar ?? new InMemoryCookieJar())
       : undefined;

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -82,6 +82,82 @@ test("HTTP client should persist cookies when stickySessions is enabled", async 
   }
 });
 
+test("HTTP client should enable sticky sessions by default in Node.js", async () => {
+  const fetchMock = jest
+    .spyOn(globalThis, "fetch")
+    .mockResolvedValueOnce(
+      new Response("{}", {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          "x-reduct-api": "1.19",
+          "set-cookie": "AWSALB=abc; Path=/; HttpOnly",
+        },
+      }) as unknown as globalThis.Response,
+    )
+    .mockResolvedValueOnce(
+      new Response("{}", {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          "x-reduct-api": "1.19",
+        },
+      }) as unknown as globalThis.Response,
+    );
+
+  try {
+    const client = new HttpClient("http://localhost:8383");
+
+    await client.get("/info");
+    await client.get("/info");
+
+    const secondCallInit = fetchMock.mock.calls[1][1] as RequestInit;
+    const headers = secondCallInit.headers as Record<string, string>;
+    expect(headers.Cookie).toBe("AWSALB=abc");
+  } finally {
+    fetchMock.mockRestore();
+  }
+});
+
+test("HTTP client should allow disabling sticky sessions explicitly", async () => {
+  const fetchMock = jest
+    .spyOn(globalThis, "fetch")
+    .mockResolvedValueOnce(
+      new Response("{}", {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          "x-reduct-api": "1.19",
+          "set-cookie": "AWSALB=abc; Path=/; HttpOnly",
+        },
+      }) as unknown as globalThis.Response,
+    )
+    .mockResolvedValueOnce(
+      new Response("{}", {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          "x-reduct-api": "1.19",
+        },
+      }) as unknown as globalThis.Response,
+    );
+
+  try {
+    const client = new HttpClient("http://localhost:8383", {
+      stickySessions: false,
+    });
+
+    await client.get("/info");
+    await client.get("/info");
+
+    const secondCallInit = fetchMock.mock.calls[1][1] as RequestInit;
+    const headers = secondCallInit.headers as Record<string, string>;
+    expect(headers.Cookie).toBeUndefined();
+  } finally {
+    fetchMock.mockRestore();
+  }
+});
+
 test("HTTP client should use custom cookie jar when provided", async () => {
   const jar = {
     getCookieHeader: jest.fn().mockReturnValue("AWSALB=from-jar"),


### PR DESCRIPTION
## Summary
- add optional `stickySessions` and `cookieJar` client options
- persist `Set-Cookie` values and replay them as `Cookie` headers across requests
- include browser `credentials: include` when sticky sessions are enabled
- add unit tests for in-memory and custom cookie jar flows

## Why
Fixes query-id loss behind load balancers where query creation and reads must hit the same replica.

Closes #150