### PR TITLE
Bind globalThis to fetch and export ReplicationMode as value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Bind `globalThis` to `fetch` when storing it as `fetchImpl` to prevent "Illegal invocation" in browsers, [PR-162](https://github.com/reductstore/reduct-js/pull/162)
+
 ## 1.19.0 - 2026-04-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.19.1 - 2026-04-08
+
 ### Fixed
 
 - Bind `globalThis` to `fetch` when storing it as `fetchImpl` to prevent "Illegal invocation" in browsers, [PR-162](https://github.com/reductstore/reduct-js/pull/162)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reduct-js",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "description": "ReductStore Client SDK for Javascript/NodeJS/Typescript",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/src/http/HttpClient.ts
+++ b/src/http/HttpClient.ts
@@ -118,7 +118,9 @@ export class HttpClient {
     }
 
     this.fetchImpl =
-      this.dispatcher && undiciFetchImpl ? undiciFetchImpl : globalThis.fetch;
+      this.dispatcher && undiciFetchImpl
+        ? undiciFetchImpl
+        : globalThis.fetch.bind(globalThis);
   }
 
   async close(): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { Status } from "./messages/Status";
 import { Token, TokenPermissions, TokenCreateRequest } from "./messages/Token";
 import { ReplicationInfo } from "./messages/ReplicationInfo";
 import { ReplicationSettings } from "./messages/ReplicationSettings";
+import { ReplicationMode } from "./messages/ReplicationMode";
 import { FullReplicationInfo } from "./messages/ReplicationInfo";
 import { Batch } from "./Batch";
 import { RecordBatch, RecordBatchType } from "./RecordBatch";
@@ -36,7 +37,7 @@ export {
   Batch,
   RecordBatch,
   RecordBatchType,
+  ReplicationMode,
 };
 
-export { ReplicationMode } from "./messages/ReplicationMode";
 export type { WriteOptions };


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

Bind `globalThis` to `fetch` when storing it as `fetchImpl` to prevent "Illegal invocation" in browsers

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
