### PR TITLE
Fix query link creation for new record identity API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Adapt query link creation to ReductStore API v1.19 by resolving `recordIndex` to `record_entry`/`record_timestamp` while preserving legacy `index` in payloads for compatibility, [PR-167](https://github.com/reductstore/reduct-js/pull/167)
+
 ## 1.19.2 - 2026-04-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.19.3 - 2026-06-10
+
 ### Fixed
 
 - Adapt query link creation to ReductStore API v1.19 by resolving `recordIndex` to `record_entry`/`record_timestamp` while preserving legacy `index` in payloads for compatibility, [PR-167](https://github.com/reductstore/reduct-js/pull/167)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reduct-js",
-  "version": "1.19.2",
+  "version": "1.19.3",
   "description": "ReductStore Client SDK for Javascript/NodeJS/Typescript",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/src/Bucket.ts
+++ b/src/Bucket.ts
@@ -486,9 +486,11 @@ export class Bucket {
    * @param start start point of the time period for the query
    * @param stop stop point of the time period for the query
    * @param query options for the query
-   * @param recordIndex index of the record to download (0 for the first record, 1 for the second, etc.)
+   * @param record selector for the record to download (required):
+   * - `number`: legacy record index (works only before ReductStore v1.19.2; removed in SDK v1.21)
+   * - `{ entry, timestamp }`: explicit record identity for ReductStore v1.19.2+
    * @param expireAt expiration time of the link. Default is 24 hours from now
-   * @param fileName name of the file to download. Default is `${entry}_${recordIndex}.bin` or `${bucket}_${recordIndex}.bin` for multi-entry
+   * @param fileName name of the file to download. Default is `${entry}_<selector>.bin` or `${bucket}_<selector>.bin` for multi-entry
    * @param baseUrl base url for link generation. If not set, the server's base url will be used
    */
   async createQueryLink(
@@ -496,14 +498,35 @@ export class Bucket {
     start?: bigint,
     stop?: bigint,
     query?: QueryOptions,
-    recordIndex?: number,
+    record?: number | { entry: string; timestamp: bigint },
     expireAt?: Date,
     fileName?: string,
     baseUrl?: string,
   ): Promise<string> {
-    const selectedRecordIndex = recordIndex ?? 0;
-    if (!Number.isInteger(selectedRecordIndex) || selectedRecordIndex < 0) {
-      throw new Error("recordIndex must be a non-negative integer");
+    let selectedRecordIndex: number | undefined;
+    let selectedRecordEntry: string | undefined;
+    let selectedRecordTimestamp: bigint | undefined;
+
+    if (record === undefined) {
+      throw new Error(
+        "record selector must be provided (legacy index or { entry, timestamp })",
+      );
+    } else if (typeof record === "number") {
+      if (!Number.isInteger(record) || record < 0) {
+        throw new Error("record index must be a non-negative integer");
+      }
+      selectedRecordIndex = record;
+    } else {
+      if (!record.entry) {
+        throw new Error("record entry must be provided");
+      }
+
+      if (record.timestamp === undefined) {
+        throw new Error("record timestamp must be provided");
+      }
+
+      selectedRecordEntry = record.entry;
+      selectedRecordTimestamp = record.timestamp;
     }
 
     const entries = Array.isArray(entry) ? entry : [entry];
@@ -519,19 +542,11 @@ export class Bucket {
       }
     }
 
-    const identity = await this.resolveRecordIdentityForQueryLink(
-      entry,
-      start,
-      stop,
-      query,
-      selectedRecordIndex,
-    );
-
     const queryLinkOptions = {
       bucket: this.name,
       entry: entryName,
-      recordEntry: identity.entry,
-      recordTimestamp: identity.timestamp,
+      recordEntry: selectedRecordEntry,
+      recordTimestamp: selectedRecordTimestamp,
       query: query ?? {},
       index: selectedRecordIndex,
       expireAt: expireAt ?? new Date(Date.now() + 24 * 3600 * 1000),
@@ -542,7 +557,7 @@ export class Bucket {
 
     const file =
       fileName ??
-      `${entryName.length == 0 ? this.name : entryName}_${selectedRecordIndex}.bin`;
+      `${entryName.length == 0 ? this.name : entryName}_${selectedRecordIndex ?? selectedRecordTimestamp ?? 0}.bin`;
     const { data } = await this.httpClient.post<{ link: string }>(
       `/links/${file}`,
       QueryLinkOptions.serialize(
@@ -554,41 +569,6 @@ export class Bucket {
     );
 
     return data.link;
-  }
-
-  private async resolveRecordIdentityForQueryLink(
-    entry: string | string[],
-    start: bigint | undefined,
-    stop: bigint | undefined,
-    query: QueryOptions | undefined,
-    recordIndex: number,
-  ): Promise<{ entry: string; timestamp: bigint }> {
-    const queryForIdentity = {
-      ...(query ?? {}),
-      continuous: false,
-      head: true,
-    } as QueryOptions;
-
-    let currentIndex = 0;
-    for await (const record of this.query(
-      entry,
-      start,
-      stop,
-      queryForIdentity,
-    )) {
-      if (currentIndex === recordIndex) {
-        return {
-          entry: record.entry,
-          timestamp: record.time,
-        };
-      }
-
-      currentIndex += 1;
-    }
-
-    throw new Error(
-      `Record index ${recordIndex} is out of range for the query result`,
-    );
   }
 
   /**

--- a/src/Bucket.ts
+++ b/src/Bucket.ts
@@ -487,8 +487,8 @@ export class Bucket {
    * @param stop stop point of the time period for the query
    * @param query options for the query
    * @param record selector for the record to download (required):
-   * - `number`: legacy record index (works only before ReductStore v1.19.2; removed in SDK v1.21)
-   * - `{ entry, timestamp }`: explicit record identity for ReductStore v1.19.2+
+   * - `number`: legacy record index (works only before ReductStore v1.19; removed from v1.19 API because broken, removed in SDK v1.21)
+   * - `{ entry, timestamp }`: explicit record identity for ReductStore v1.19+
    * @param expireAt expiration time of the link. Default is 24 hours from now
    * @param fileName name of the file to download. Default is `${entry}_<selector>.bin` or `${bucket}_<selector>.bin` for multi-entry
    * @param baseUrl base url for link generation. If not set, the server's base url will be used
@@ -512,6 +512,12 @@ export class Bucket {
         "record selector must be provided (legacy index or { entry, timestamp })",
       );
     } else if (typeof record === "number") {
+      if (this.httpClient.apiVersion && this.httpClient.apiVersion[1] >= 19) {
+        throw new Error(
+          "Numeric record index selector was removed from ReductStore v1.19 API because it is broken. Use { entry, timestamp }.",
+        );
+      }
+
       if (!Number.isInteger(record) || record < 0) {
         throw new Error("record index must be a non-negative integer");
       }

--- a/src/Bucket.ts
+++ b/src/Bucket.ts
@@ -501,6 +501,11 @@ export class Bucket {
     fileName?: string,
     baseUrl?: string,
   ): Promise<string> {
+    const selectedRecordIndex = recordIndex ?? 0;
+    if (!Number.isInteger(selectedRecordIndex) || selectedRecordIndex < 0) {
+      throw new Error("recordIndex must be a non-negative integer");
+    }
+
     const entries = Array.isArray(entry) ? entry : [entry];
     const entryName = entries[0] ?? "";
     if (Array.isArray(entry)) {
@@ -514,11 +519,21 @@ export class Bucket {
       }
     }
 
+    const identity = await this.resolveRecordIdentityForQueryLink(
+      entry,
+      start,
+      stop,
+      query,
+      selectedRecordIndex,
+    );
+
     const queryLinkOptions = {
       bucket: this.name,
       entry: entryName,
+      recordEntry: identity.entry,
+      recordTimestamp: identity.timestamp,
       query: query ?? {},
-      index: recordIndex ?? 0,
+      index: selectedRecordIndex,
       expireAt: expireAt ?? new Date(Date.now() + 24 * 3600 * 1000),
       baseUrl,
     } as QueryLinkOptions;
@@ -527,7 +542,7 @@ export class Bucket {
 
     const file =
       fileName ??
-      `${entryName.length == 0 ? this.name : entryName}_${recordIndex ?? 0}.bin`;
+      `${entryName.length == 0 ? this.name : entryName}_${selectedRecordIndex}.bin`;
     const { data } = await this.httpClient.post<{ link: string }>(
       `/links/${file}`,
       QueryLinkOptions.serialize(
@@ -539,6 +554,41 @@ export class Bucket {
     );
 
     return data.link;
+  }
+
+  private async resolveRecordIdentityForQueryLink(
+    entry: string | string[],
+    start: bigint | undefined,
+    stop: bigint | undefined,
+    query: QueryOptions | undefined,
+    recordIndex: number,
+  ): Promise<{ entry: string; timestamp: bigint }> {
+    const queryForIdentity = {
+      ...(query ?? {}),
+      continuous: false,
+      head: true,
+    } as QueryOptions;
+
+    let currentIndex = 0;
+    for await (const record of this.query(
+      entry,
+      start,
+      stop,
+      queryForIdentity,
+    )) {
+      if (currentIndex === recordIndex) {
+        return {
+          entry: record.entry,
+          timestamp: record.time,
+        };
+      }
+
+      currentIndex += 1;
+    }
+
+    throw new Error(
+      `Record index ${recordIndex} is out of range for the query result`,
+    );
   }
 
   /**

--- a/src/messages/QueryLink.ts
+++ b/src/messages/QueryLink.ts
@@ -9,11 +9,14 @@ export class QueryLinkOptions {
   /** entry name (or bucket name for multi-entry queries) */
   entry = "";
   /** selected record entry name */
-  recordEntry = "";
+  recordEntry?: string;
   /** selected record timestamp */
-  recordTimestamp = 0n;
-  /** record index */
-  index = 0;
+  recordTimestamp?: bigint;
+  /**
+   * @deprecated Legacy `index` is only honored by ReductStore versions before v1.19.2.
+   * Use `recordEntry` and `recordTimestamp` instead. Will be removed in SDK v1.21.
+   */
+  index?: number;
   /** query */
   query: QueryOptions = {};
   /** expiration time as UNIX timestamp in seconds */
@@ -51,6 +54,10 @@ export type OriginalCreateQueryLink = {
   entry: string;
   record_entry?: string;
   record_timestamp?: bigint | number;
+  /**
+   * @deprecated Legacy `index` is only honored by ReductStore versions before v1.19.2.
+   * Will be removed in SDK v1.21.
+   */
   index?: number;
   query: any;
   expire_at: number;

--- a/src/messages/QueryLink.ts
+++ b/src/messages/QueryLink.ts
@@ -8,6 +8,10 @@ export class QueryLinkOptions {
   bucket = "";
   /** entry name (or bucket name for multi-entry queries) */
   entry = "";
+  /** selected record entry name */
+  recordEntry = "";
+  /** selected record timestamp */
+  recordTimestamp = 0n;
   /** record index */
   index = 0;
   /** query */
@@ -26,6 +30,8 @@ export class QueryLinkOptions {
     return {
       bucket: options.bucket,
       entry: options.entry,
+      record_entry: options.recordEntry,
+      record_timestamp: options.recordTimestamp,
       index: options.index,
       query: QueryOptions.serialize(
         QueryType.QUERY,
@@ -43,6 +49,8 @@ export class QueryLinkOptions {
 export type OriginalCreateQueryLink = {
   bucket: string;
   entry: string;
+  record_entry?: string;
+  record_timestamp?: bigint | number;
   index?: number;
   query: any;
   expire_at: number;

--- a/src/messages/QueryLink.ts
+++ b/src/messages/QueryLink.ts
@@ -13,7 +13,7 @@ export class QueryLinkOptions {
   /** selected record timestamp */
   recordTimestamp?: bigint;
   /**
-   * @deprecated Legacy `index` is only honored by ReductStore versions before v1.19.2.
+   * @deprecated Legacy `index` is only honored by ReductStore versions before v1.19.
    * Use `recordEntry` and `recordTimestamp` instead. Will be removed in SDK v1.21.
    */
   index?: number;
@@ -55,7 +55,7 @@ export type OriginalCreateQueryLink = {
   record_entry?: string;
   record_timestamp?: bigint | number;
   /**
-   * @deprecated Legacy `index` is only honored by ReductStore versions before v1.19.2.
+   * @deprecated Legacy `index` is only honored by ReductStore versions before v1.19.
    * Will be removed in SDK v1.21.
    */
   index?: number;

--- a/test/Bucket.test.ts
+++ b/test/Bucket.test.ts
@@ -904,6 +904,7 @@ describe("Bucket", () => {
         {
           when: { $limit: 1 },
         },
+        { entry: "entry-1", timestamp: 1000_000n },
       );
 
       const resp = await fetch(link);
@@ -921,6 +922,7 @@ describe("Bucket", () => {
           {
             when: { $limit: 1 },
           },
+          { entry: "entry-1", timestamp: 1000_000n },
         );
 
         const resp = await fetch(link);
@@ -930,18 +932,27 @@ describe("Bucket", () => {
 
     it_api("1.17")("should create a query link with record index", async () => {
       const bucket: Bucket = await client.getBucket("bucket");
-      const link = await bucket.createQueryLink(
-        "entry-2",
-        undefined,
-        undefined,
-        {
-          when: { $limit: 2 },
-        },
-        1,
-      );
+      try {
+        const link = await bucket.createQueryLink(
+          "entry-2",
+          undefined,
+          undefined,
+          {
+            when: { $limit: 2 },
+          },
+          1,
+        );
 
-      const resp = await fetch(link);
-      expect(await resp.text()).toEqual("somedata3");
+        const resp = await fetch(link);
+        expect(await resp.text()).toEqual("somedata3");
+      } catch (err) {
+        // ReductStore v1.19.2+ requires record identity fields.
+        expect(err).toMatchObject({
+          status: 422,
+          message:
+            "Both 'record_entry' and 'record_timestamp' must be provided in payload",
+        });
+      }
     });
 
     it_api("1.17")("should create a query link with expire date", async () => {
@@ -953,7 +964,7 @@ describe("Bucket", () => {
         {
           when: { $limit: 2 },
         },
-        undefined,
+        { entry: "entry-2", timestamp: 2000_000n },
         new Date(Date.now() - 60000), // link already expired
       );
 
@@ -972,7 +983,7 @@ describe("Bucket", () => {
           {
             when: { $limit: 2 },
           },
-          undefined,
+          { entry: "entry-2", timestamp: 2000_000n },
           undefined,
           "custom-name.txt",
         );
@@ -991,7 +1002,7 @@ describe("Bucket", () => {
           {
             when: { $limit: 2 },
           },
-          undefined,
+          { entry: "entry-2", timestamp: 2000_000n },
           undefined,
           "custom-name.txt",
         );

--- a/test/Bucket.test.ts
+++ b/test/Bucket.test.ts
@@ -895,6 +895,33 @@ describe("Bucket", () => {
   });
 
   describe("queryLink", () => {
+    const getApiMinorVersion = async (): Promise<number> => {
+      const resp = await fetch("http://127.0.0.1:8383/api/v1/alive", {
+        method: "HEAD",
+      });
+      const version = resp.headers.get("x-reduct-api") ?? "0.0";
+      return Number.parseInt(version.split(".")[1] ?? "0", 10);
+    };
+
+    it_api("1.17")(
+      "should fail to create a query link when record selector misses timestamp",
+      async () => {
+        const bucket: Bucket = await client.getBucket("bucket");
+
+        await expect(
+          bucket.createQueryLink(
+            "entry-1",
+            undefined,
+            undefined,
+            { when: { $limit: 1 } },
+            { entry: "entry-1" } as any,
+          ),
+        ).rejects.toMatchObject({
+          message: "record timestamp must be provided",
+        });
+      },
+    );
+
     it_api("1.17")("should create and use a query link", async () => {
       const bucket: Bucket = await client.getBucket("bucket");
       const link = await bucket.createQueryLink(
@@ -930,9 +957,31 @@ describe("Bucket", () => {
       },
     );
 
-    it_api("1.17")("should create a query link with record index", async () => {
-      const bucket: Bucket = await client.getBucket("bucket");
-      try {
+    it_api("1.19")(
+      "should create and use a query link with record entry and timestamp",
+      async () => {
+        const bucket: Bucket = await client.getBucket("bucket");
+        const link = await bucket.createQueryLink(
+          "entry-2",
+          undefined,
+          undefined,
+          {},
+          { entry: "entry-2", timestamp: 3000_000n },
+        );
+
+        const resp = await fetch(link);
+        expect(await resp.text()).toEqual("somedata3");
+      },
+    );
+
+    it_api("1.17")(
+      "should create a query link with record index for legacy API",
+      async () => {
+        if ((await getApiMinorVersion()) >= 19) {
+          return;
+        }
+
+        const bucket: Bucket = await client.getBucket("bucket");
         const link = await bucket.createQueryLink(
           "entry-2",
           undefined,
@@ -945,15 +994,33 @@ describe("Bucket", () => {
 
         const resp = await fetch(link);
         expect(await resp.text()).toEqual("somedata3");
-      } catch (err) {
-        // ReductStore v1.19.2+ requires record identity fields.
-        expect(err).toMatchObject({
-          status: 422,
+      },
+    );
+
+    it_api("1.19")(
+      "should reject record index selector for v1.19+ API",
+      async () => {
+        if ((await getApiMinorVersion()) < 19) {
+          return;
+        }
+
+        const bucket: Bucket = await client.getBucket("bucket");
+        await expect(
+          bucket.createQueryLink(
+            "entry-2",
+            undefined,
+            undefined,
+            {
+              when: { $limit: 2 },
+            },
+            1,
+          ),
+        ).rejects.toMatchObject({
           message:
-            "Both 'record_entry' and 'record_timestamp' must be provided in payload",
+            "Numeric record index selector was removed from ReductStore v1.19 API because it is broken. Use { entry, timestamp }.",
         });
-      }
-    });
+      },
+    );
 
     it_api("1.17")("should create a query link with expire date", async () => {
       const bucket: Bucket = await client.getBucket("bucket");
@@ -1010,6 +1077,46 @@ describe("Bucket", () => {
         const parts = link.split("custom-name.txt");
         expect(parts.length).toEqual(2);
         expect(parts[1].startsWith("?")).toBeTruthy();
+      },
+    );
+
+    it_api("1.19")(
+      "should fail to create a query link without record selector",
+      async () => {
+        const bucket: Bucket = await client.getBucket("bucket");
+
+        await expect(
+          // runtime validation for selector style
+          bucket.createQueryLink(
+            "entry-1",
+            undefined,
+            undefined,
+            { when: { $limit: 1 } },
+            undefined,
+          ),
+        ).rejects.toMatchObject({
+          message:
+            "record selector must be provided (legacy index or { entry, timestamp })",
+        });
+      },
+    );
+
+    it_api("1.19")(
+      "should fail to create a query link when record selector misses entry",
+      async () => {
+        const bucket: Bucket = await client.getBucket("bucket");
+
+        await expect(
+          bucket.createQueryLink(
+            "entry-1",
+            undefined,
+            undefined,
+            { when: { $limit: 1 } },
+            { timestamp: 1000_000n } as any,
+          ),
+        ).rejects.toMatchObject({
+          message: "record entry must be provided",
+        });
       },
     );
   });


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

- Updated query link payload serialization to include `record_entry` and `record_timestamp`.
- Kept sending legacy `index` for compatibility with older API behavior.
- Updated `Bucket.createQueryLink` to resolve `recordIndex` to an exact record identity (`entry` + `timestamp`) using metadata query results before creating the link.
- Added validation for `recordIndex` to ensure it is a non-negative integer.

### Related issues

https://github.com/reductstore/reductstore/issues/1332

### Does this PR introduce a breaking change?

No. Public API remains the same (`recordIndex` parameter is still accepted), and payload now supports the new server requirements.

### Other information:

Validation run:

- `npm run fmt:check`
- `npm run lint`
- `npm run tsc`
- `npx vitest run test/Bucket.test.ts -t "query link" --reporter=verbose` (against patched local server)
