### PR TITLE
Harden CI GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
     branches: [main]
 
 permissions:
-  id-token: write # Required for OIDC
   contents: read
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Security
+
+- Restrict GitHub Actions `GITHUB_TOKEN` default permissions to `contents: read` in CI workflow and remove unnecessary OIDC write access.
+
 ## 1.19.3 - 2026-06-10
 
 ### Fixed


### PR DESCRIPTION
Closes #168

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Security hardening / CI workflow configuration update.

### What was changed?

- Reduced default `GITHUB_TOKEN` permissions in `.github/workflows/ci.yml` to least privilege (`contents: read`).
- Removed unnecessary workflow-wide `id-token: write` permission so CI/test/lint/audit/publish jobs no longer get OIDC write access by default.
- Added an Unreleased `Security` entry in `CHANGELOG.md`.

This implementation follows the approved plan in issue #168 comment:
https://github.com/reductstore/reduct-js/issues/168#issuecomment-4350722670

### Related issues

- https://github.com/reductstore/reduct-js/issues/168

### Does this PR introduce a breaking change?

No.

### Other information:

Validation run locally:
- `npm run fmt:check`
- `npm run lint`
