### PR TITLE
Pin docker/login-action to immutable SHA in CI (issue #170)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: npm i
       - run: npm run fmt:check
 
@@ -27,10 +27,10 @@ jobs:
         token: ["", "token"]
         reductstore_version: ["main", "latest"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: install node js ${{ matrix.node_version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "${{ matrix.node_version }}"
       - run: npm i
@@ -70,9 +70,9 @@ jobs:
         example: ["HelloWorld.js", "QuickStart.js", "Subscription.js"]
         reductstore_version: ["main", "latest"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: install node js ${{ matrix.node_version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "${{ matrix.node_version }}"
       - run: npm i
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: format
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: npm i
       - name: Run tests
         run: npm run lint
@@ -123,7 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: format
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: npm i
       - name: Fail on high/critical vulnerabilities
         run: npm audit --audit-level=high
@@ -133,8 +133,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.event.ref, 'refs/tags/v') }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - run: npm i
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
@@ -78,7 +78,7 @@ jobs:
       - run: npm i
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - Restrict GitHub Actions `GITHUB_TOKEN` default permissions to `contents: read` in CI workflow and remove unnecessary OIDC write access.
+- Pin `docker/login-action` in CI workflow to an immutable commit SHA (updated to v4.1.0), issue #170
 
 ## 1.19.3 - 2026-06-10
 


### PR DESCRIPTION
Closes #170

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Security hardening / CI workflow maintenance.

### What was changed?

- Updated `docker/login-action` from `@v3` to an immutable commit SHA pinned to `v4.1.0` in `.github/workflows/ci.yml`.
- Applied the same pinning in both workflow jobs that log in to GHCR.
- Added an Unreleased `Security` changelog note for issue #170.

Plan reference: https://github.com/reductstore/reduct-js/issues/170#issuecomment-4395520436

### Related issues

- https://github.com/reductstore/reduct-js/issues/170
- Parent tracking: https://github.com/reductstore/security/issues/22

### Does this PR introduce a breaking change?

No.

### Other information:

Validation run:
- `npm run fmt:check` ✅
- `npm run lint` ✅
- `npm test` ❌ (fails in this environment with `Unknown Error: fetch failed` across existing integration-style tests)