### PR TITLE
Revert "171 feat support non json content types in write attachmentsread attachments (#172)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Added
-
-- Support non-JSON content types in `writeAttachments` and `readAttachments`, [PR-172](https://github.com/reductstore/reduct-js/pull/172)
-
 ### Security
 
 - Restrict GitHub Actions `GITHUB_TOKEN` default permissions to `contents: read` in CI workflow and remove unnecessary OIDC write access.

--- a/src/Bucket.ts
+++ b/src/Bucket.ts
@@ -1,5 +1,4 @@
 // @ts-ignore`
-import { Buffer } from "buffer";
 import { BucketSettings } from "./messages/BucketSettings";
 import { BucketInfo } from "./messages/BucketInfo";
 import { EntryInfo } from "./messages/EntryInfo";
@@ -589,20 +588,20 @@ export class Bucket {
   async writeAttachments(
     entry: string,
     attachments: Record<string, unknown>,
-    contentType?: string,
   ): Promise<void> {
-    const ct = contentType ?? "application/json";
-    const isJson = isJsonContentType(ct);
     const batch = this.beginWriteRecordBatch();
     const entryName = `${entry}/$meta`;
     const baseTs = BigInt(Date.now()) * 1000n;
     let offset = 0n;
 
     for (const [key, content] of Object.entries(attachments)) {
-      const data = isJson
-        ? JSON.stringify(content)
-        : Buffer.from(content as string, "base64");
-      batch.add(entryName, baseTs + offset, data, ct, { key });
+      batch.add(
+        entryName,
+        baseTs + offset,
+        JSON.stringify(content),
+        "application/json",
+        { key },
+      );
       offset += 1n;
     }
 
@@ -625,12 +624,7 @@ export class Bucket {
       }
 
       const key = record.labels["key"].toString();
-      if (isJsonContentType(record.contentType ?? "")) {
-        attachments[key] = JSON.parse(await record.readAsString());
-      } else {
-        const buf = await record.read();
-        attachments[key] = buf.toString("base64");
-      }
+      attachments[key] = JSON.parse(await record.readAsString());
     }
 
     return attachments;
@@ -673,11 +667,4 @@ export class Bucket {
 
     await batch.send();
   }
-}
-
-function isJsonContentType(contentType: string): boolean {
-  const ct = contentType.split(";")[0].trim().toLowerCase();
-  return (
-    ct === "application/json" || ct === "text/json" || ct.endsWith("+json")
-  );
 }

--- a/test/Bucket.test.ts
+++ b/test/Bucket.test.ts
@@ -864,40 +864,6 @@ describe("Bucket", () => {
         });
       },
     );
-
-    it_api("1.19", true)(
-      "should write and read non-JSON attachments",
-      async () => {
-        const bucket: Bucket = await client.getBucket("bucket");
-        const rawBytes = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
-        const encoded = rawBytes.toString("base64");
-
-        await bucket.writeAttachments(
-          "entry-1",
-          { "binary-data": encoded },
-          "application/octet-stream",
-        );
-
-        const attachments = await bucket.readAttachments("entry-1");
-        expect(attachments["binary-data"]).toEqual(encoded);
-      },
-    );
-
-    it_api("1.19", true)(
-      "should write and read JSON attachments with default content type",
-      async () => {
-        const bucket: Bucket = await client.getBucket("bucket");
-        await bucket.writeAttachments("entry-1", {
-          "meta-1": { enabled: true, values: [1, 2, 3] },
-          "meta-2": { name: "test" },
-        });
-
-        await expect(bucket.readAttachments("entry-1")).resolves.toEqual({
-          "meta-1": { enabled: true, values: [1, 2, 3] },
-          "meta-2": { name: "test" },
-        });
-      },
-    );
   });
 
   describe("rename", () => {


### PR DESCRIPTION
Reverts the SDK-side support for non-JSON attachment content types that was added to match reductstore/reductstore#1372.

This rollback keeps the SDK behavior aligned with the reverted server behavior.