### PR TITLE
Fix publish permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,10 @@ jobs:
   publish:
     needs: [run_tests, run_examples, lint, audit]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
     if: ${{ startsWith(github.event.ref, 'refs/tags/v') }}
     steps:
       - uses: actions/checkout@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Restrict GitHub Actions `GITHUB_TOKEN` default permissions to `contents: read` in CI workflow and remove unnecessary OIDC write access.
 - Pin `docker/login-action` in CI workflow to an immutable commit SHA (updated to v4.1.0), issue #170
 
-## 1.19.3 - 2026-06-10
+## 1.19.3 - 2026-04-15
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 1.20.0-beta.1 - 2026-05-18
-
 ### Added
 
 - Add lifecycle policy API support, [PR-175](https://github.com/reductstore/reduct-js/pull/175)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Restore OIDC token write permission for the publish job while keeping default workflow permissions restricted, [PR-176](https://github.com/reductstore/reduct-js/pull/176)
 - Restrict GitHub Actions `GITHUB_TOKEN` default permissions to `contents: read` in CI workflow and remove unnecessary OIDC write access.
 - Pin `docker/login-action` in CI workflow to an immutable commit SHA (updated to v4.1.0), issue #170
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reduct-js",
-  "version": "1.20.0-beta.1",
+  "version": "1.20.0-beta.2",
   "description": "ReductStore Client SDK for Javascript/NodeJS/Typescript",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

CI/release maintenance

### What was changed?

- Restore `id-token: write` permission for the publish job so trusted publishing can request an OIDC token while keeping the workflow default permissions restricted.
- Bump the package version to `1.20.0-beta.2`.
- Keep the current beta changes under `Unreleased` and correct the `1.19.3` release date.

### Related issues

Related to #170

### Does this PR introduce a breaking change?

No.

### Other information:

Tests were not run locally because this change only adjusts release metadata and CI publishing permissions.