### PR TITLE
Use x-reduct-content-length instead of Content-Length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add lifecycle policy API support, [PR-175](https://github.com/reductstore/reduct-js/pull/175)
 
+### Fixed
+
+- Use `x-reduct-content-length` instead of `Content-Length` for browser compatibility with undici
+
 ### Security
 
 - Restore OIDC token write permission for the publish job while keeping default workflow permissions restricted, [PR-176](https://github.com/reductstore/reduct-js/pull/176)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Use `x-reduct-content-length` instead of `Content-Length` for browser compatibility with undici
+- Use `x-reduct-content-length` instead of `Content-Length` for browser compatibility with undici, [PR-179](https://github.com/reductstore/reduct-js/pull/179)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Use `x-reduct-content-length` instead of `Content-Length` for browser compatibility with undici, [PR-179](https://github.com/reductstore/reduct-js/pull/179)
+- Fix duplicate `Content-Length` for buffer/string writes and use `x-reduct-content-length` for stream writes to support browser streaming (requires server ≥1.20), [PR-179](https://github.com/reductstore/reduct-js/pull/179)
 
 ### Security
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reduct-js",
-  "version": "1.20.0-beta.2",
+  "version": "1.20.0-beta.3",
   "description": "ReductStore Client SDK for Javascript/NodeJS/Typescript",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/src/Batch.ts
+++ b/src/Batch.ts
@@ -1,7 +1,6 @@
 import { LabelMap } from "./Record";
 import { APIError } from "./APIError";
 import { HttpClient } from "./http/HttpClient";
-import { isBrowser } from "./utils/env";
 
 /**
  * Represents a batch of records for writing
@@ -108,9 +107,7 @@ export class Batch {
   public async write(): Promise<Map<bigint, APIError>> {
     const headers: Record<string, string> = {};
     const chunks: Buffer[] = [];
-    let contentLength = 0;
     for (const [ts, { data, contentType, labels }] of this.items()) {
-      contentLength += data.length;
       chunks.push(data);
       const headerName = `x-reduct-time-${ts}`;
 
@@ -133,25 +130,11 @@ export class Batch {
     let response;
     switch (this.type) {
       case BatchType.WRITE: {
-        const stream = new ReadableStream<Uint8Array>({
-          start(ctrl) {
-            for (const chunk of chunks) {
-              ctrl.enqueue(chunk);
-            }
-            ctrl.close();
-          },
-        });
-
         headers["Content-Type"] = "application/octet-stream";
-        if (isBrowser) {
-          headers["x-reduct-content-length"] = contentLength.toString();
-        } else {
-          headers["Content-Length"] = contentLength.toString();
-        }
 
         response = await this.httpClient.post(
           `/b/${this.bucketName}/${this.entryName}/batch`,
-          stream,
+          Buffer.concat(chunks),
           headers,
         );
         break;

--- a/src/Batch.ts
+++ b/src/Batch.ts
@@ -143,6 +143,8 @@ export class Batch {
 
         headers["Content-Type"] = "application/octet-stream";
         headers["x-reduct-content-length"] = contentLength.toString();
+        // Send Content-Length for compatibility (server <1.20)
+        headers["Content-Length"] = contentLength.toString();
 
         response = await this.httpClient.post(
           `/b/${this.bucketName}/${this.entryName}/batch`,

--- a/src/Batch.ts
+++ b/src/Batch.ts
@@ -1,6 +1,7 @@
 import { LabelMap } from "./Record";
 import { APIError } from "./APIError";
 import { HttpClient } from "./http/HttpClient";
+import { isBrowser } from "./utils/env";
 
 /**
  * Represents a batch of records for writing
@@ -142,9 +143,11 @@ export class Batch {
         });
 
         headers["Content-Type"] = "application/octet-stream";
-        headers["x-reduct-content-length"] = contentLength.toString();
-        // Send Content-Length for compatibility (server <1.20)
-        headers["Content-Length"] = contentLength.toString();
+        if (isBrowser) {
+          headers["x-reduct-content-length"] = contentLength.toString();
+        } else {
+          headers["Content-Length"] = contentLength.toString();
+        }
 
         response = await this.httpClient.post(
           `/b/${this.bucketName}/${this.entryName}/batch`,

--- a/src/Batch.ts
+++ b/src/Batch.ts
@@ -142,7 +142,7 @@ export class Batch {
         });
 
         headers["Content-Type"] = "application/octet-stream";
-        headers["Content-Length"] = contentLength.toString();
+        headers["x-reduct-content-length"] = contentLength.toString();
 
         response = await this.httpClient.post(
           `/b/${this.bucketName}/${this.entryName}/batch`,

--- a/src/Bucket.ts
+++ b/src/Bucket.ts
@@ -444,7 +444,7 @@ export class Bucket {
   /**
    * Create a new batch for writing records to multiple entries.
    * @example
-   * const batch = await bucket.beginWriteRecordBatch();
+   * const batch = bucket.beginWriteRecordBatch();
    * batch.add("entry-1", 1000n, "data");
    * batch.add("entry-2", 2000n, "data");
    * await batch.send();

--- a/src/Record.ts
+++ b/src/Record.ts
@@ -1,7 +1,6 @@
 import { Buffer } from "buffer";
 import { WriteOptions } from "./Bucket";
 import { HttpClient } from "./http/HttpClient";
-import { isBrowser } from "./utils/env";
 
 export type LabelMap = Record<string, string | number | boolean | bigint>;
 
@@ -154,12 +153,10 @@ export class WritableRecord {
 
     const headers: Record<string, string> = {
       "Content-Type": options.contentType ?? "application/octet-stream",
-      ...(dataToSend instanceof ReadableStream
-        ? isBrowser
-          ? { "x-reduct-content-length": contentLength.toString() }
-          : { "Content-Length": contentLength.toString() }
-        : {}),
     };
+    if (dataToSend instanceof ReadableStream) {
+      headers["x-reduct-content-length"] = contentLength.toString();
+    }
 
     for (const [key, value] of Object.entries(options.labels ?? {})) {
       headers[`x-reduct-label-${key}`] = value.toString();

--- a/src/Record.ts
+++ b/src/Record.ts
@@ -154,6 +154,10 @@ export class WritableRecord {
     const headers: Record<string, string> = {
       "Content-Type": options.contentType ?? "application/octet-stream",
       "x-reduct-content-length": contentLength.toString(),
+      // Send Content-Length for compatibility (server <1.20)
+      ...(dataToSend instanceof ReadableStream
+        ? { "Content-Length": contentLength.toString() }
+        : {}),
     };
 
     for (const [key, value] of Object.entries(options.labels ?? {})) {

--- a/src/Record.ts
+++ b/src/Record.ts
@@ -1,6 +1,7 @@
 import { Buffer } from "buffer";
 import { WriteOptions } from "./Bucket";
 import { HttpClient } from "./http/HttpClient";
+import { isBrowser } from "./utils/env";
 
 export type LabelMap = Record<string, string | number | boolean | bigint>;
 
@@ -153,10 +154,10 @@ export class WritableRecord {
 
     const headers: Record<string, string> = {
       "Content-Type": options.contentType ?? "application/octet-stream",
-      "x-reduct-content-length": contentLength.toString(),
-      // Send Content-Length for compatibility (server <1.20)
       ...(dataToSend instanceof ReadableStream
-        ? { "Content-Length": contentLength.toString() }
+        ? isBrowser
+          ? { "x-reduct-content-length": contentLength.toString() }
+          : { "Content-Length": contentLength.toString() }
         : {}),
     };
 

--- a/src/Record.ts
+++ b/src/Record.ts
@@ -153,7 +153,7 @@ export class WritableRecord {
 
     const headers: Record<string, string> = {
       "Content-Type": options.contentType ?? "application/octet-stream",
-      "Content-Length": contentLength.toString(),
+      "x-reduct-content-length": contentLength.toString(),
     };
 
     for (const [key, value] of Object.entries(options.labels ?? {})) {

--- a/src/RecordBatch.ts
+++ b/src/RecordBatch.ts
@@ -2,7 +2,6 @@ import { Buffer } from "buffer";
 import { APIError } from "./APIError";
 import { HttpClient } from "./http/HttpClient";
 import { LabelMap } from "./Record";
-import { isBrowser } from "./utils/env";
 
 const HEADER_PREFIX = "x-reduct-";
 const ERROR_HEADER_PREFIX = "x-reduct-error-";
@@ -147,31 +146,15 @@ export class RecordBatch {
 
     switch (this.type) {
       case RecordBatchType.WRITE: {
-        const { contentLength, headers, entries, startTs } =
-          makeHeadersV2(this);
+        const { headers, entries, startTs } = makeHeadersV2(this);
         const chunks: Buffer[] = [];
         for (const [, record] of this.items()) {
           chunks.push(record.data);
         }
 
-        const stream = new ReadableStream<Uint8Array>({
-          start(ctrl) {
-            for (const chunk of chunks) {
-              ctrl.enqueue(chunk);
-            }
-            ctrl.close();
-          },
-        });
-
-        if (isBrowser) {
-          headers["x-reduct-content-length"] = contentLength.toString();
-        } else {
-          headers["Content-Length"] = contentLength.toString();
-        }
-
         const response = await this.httpClient.post(
           `/io/${this.bucketName}/write`,
-          stream,
+          Buffer.concat(chunks),
           headers,
         );
 

--- a/src/RecordBatch.ts
+++ b/src/RecordBatch.ts
@@ -162,7 +162,7 @@ export class RecordBatch {
           },
         });
 
-        headers["Content-Length"] = contentLength.toString();
+        headers["x-reduct-content-length"] = contentLength.toString();
 
         const response = await this.httpClient.post(
           `/io/${this.bucketName}/write`,

--- a/src/RecordBatch.ts
+++ b/src/RecordBatch.ts
@@ -258,20 +258,18 @@ type PreparedRecords = {
 };
 
 function makeHeadersV2(batch: RecordBatch): {
-  contentLength: bigint;
   headers: Record<string, string>;
   entries: string[];
   startTs: bigint;
 } {
   const recordHeaders: Record<string, string> = {};
-  let contentLength = 0n;
   const records = batch.items();
 
   if (records.length === 0) {
     recordHeaders[ENTRIES_HEADER] = "";
     recordHeaders[START_TS_HEADER] = "0";
     recordHeaders["Content-Type"] = "application/octet-stream";
-    return { contentLength, headers: recordHeaders, entries: [], startTs: 0n };
+    return { headers: recordHeaders, entries: [], startTs: 0n };
   }
 
   const { entries, startTs, indexedRecords } = prepareRecordsV2(records);
@@ -285,7 +283,6 @@ function makeHeadersV2(batch: RecordBatch): {
   recordHeaders[START_TS_HEADER] = startTs.toString();
 
   for (const [entryIndex, timestamp, record] of indexedRecords) {
-    contentLength += BigInt(record.data.length);
     const delta = timestamp - startTs;
     const contentType = record.contentType || "application/octet-stream";
     const previous = lastMeta.get(entryIndex);
@@ -321,12 +318,7 @@ function makeHeadersV2(batch: RecordBatch): {
   }
 
   recordHeaders["Content-Type"] = "application/octet-stream";
-  return {
-    contentLength,
-    headers: recordHeaders,
-    entries,
-    startTs,
-  };
+  return { headers: recordHeaders, entries, startTs };
 }
 
 function makeUpdateHeadersV2(batch: RecordBatch): {

--- a/src/RecordBatch.ts
+++ b/src/RecordBatch.ts
@@ -163,6 +163,8 @@ export class RecordBatch {
         });
 
         headers["x-reduct-content-length"] = contentLength.toString();
+        // Send Content-Length for compatibility (server <1.20)
+        headers["Content-Length"] = contentLength.toString();
 
         const response = await this.httpClient.post(
           `/io/${this.bucketName}/write`,

--- a/src/RecordBatch.ts
+++ b/src/RecordBatch.ts
@@ -2,6 +2,7 @@ import { Buffer } from "buffer";
 import { APIError } from "./APIError";
 import { HttpClient } from "./http/HttpClient";
 import { LabelMap } from "./Record";
+import { isBrowser } from "./utils/env";
 
 const HEADER_PREFIX = "x-reduct-";
 const ERROR_HEADER_PREFIX = "x-reduct-error-";
@@ -162,9 +163,11 @@ export class RecordBatch {
           },
         });
 
-        headers["x-reduct-content-length"] = contentLength.toString();
-        // Send Content-Length for compatibility (server <1.20)
-        headers["Content-Length"] = contentLength.toString();
+        if (isBrowser) {
+          headers["x-reduct-content-length"] = contentLength.toString();
+        } else {
+          headers["Content-Length"] = contentLength.toString();
+        }
 
         const response = await this.httpClient.post(
           `/io/${this.bucketName}/write`,

--- a/test/Bucket.test.ts
+++ b/test/Bucket.test.ts
@@ -135,51 +135,38 @@ describe("Bucket", () => {
       ).rejects.toMatchObject({ status: 404 });
     });
 
-    it("should write and read a big blob as streams", async () => {
+    it_api("1.20")("should write a big blob as stream", async () => {
       const bigBlob = crypto.randomBytes(2 ** 20);
-
       const bucket: Bucket = await client.getBucket("bucket");
-      const record = await bucket.beginWrite("big-blob");
+      await (
+        await bucket.beginWrite("big-blob")
+      ).write(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(bigBlob);
+            controller.close();
+          },
+        }),
+        bigBlob.length,
+      );
+      const record = await bucket.beginRead("big-blob");
+      expect(record.size).toEqual(BigInt(bigBlob.length));
+    });
 
-      const stream = new ReadableStream<Uint8Array>({
-        start(controller) {
-          controller.enqueue(bigBlob);
-          controller.close();
-        },
-      });
+    it("should read a big blob as stream", async () => {
+      const bigBlob = crypto.randomBytes(2 ** 20);
+      const bucket: Bucket = await client.getBucket("bucket");
+      await (await bucket.beginWrite("big-blob")).write(bigBlob);
 
-      await record.write(stream, bigBlob.length);
-
-      const readStream = (await bucket.beginRead("big-blob")).stream;
-
-      // Read the stream
-      const reader = readStream.getReader();
+      const reader = (await bucket.beginRead("big-blob")).stream.getReader();
       const chunks: Uint8Array[] = [];
       let done = false;
       while (!done) {
         const { value, done: isDone } = await reader.read();
         done = isDone;
-        if (value) {
-          chunks.push(value);
-        }
+        if (value) chunks.push(value);
       }
-
-      const actualBuffer = Buffer.concat(chunks);
-
-      expect(actualBuffer.length).toEqual(bigBlob.length);
-      expect(md5(actualBuffer)).toEqual(md5(bigBlob));
-    });
-
-    it("should write and read a big blob as buffers", async () => {
-      const bigBlob = crypto.randomBytes(2 ** 20);
-
-      const bucket: Bucket = await client.getBucket("bucket");
-      const record = await bucket.beginWrite("big-blob");
-      await record.write(bigBlob);
-
-      const reader = await bucket.beginRead("big-blob");
-
-      const actual = await reader.read();
+      const actual = Buffer.concat(chunks);
       expect(actual.length).toEqual(bigBlob.length);
       expect(md5(actual)).toEqual(md5(bigBlob));
     });
@@ -293,7 +280,7 @@ describe("Bucket", () => {
       "should write a record batch to multiple entries",
       async () => {
         const bucket: Bucket = await client.getBucket("bucket");
-        const batch = await bucket.beginWriteRecordBatch();
+        const batch = bucket.beginWriteRecordBatch();
         batch.add("entry-batch-1", 1000n, "alpha", "text/plain", {
           label: "a",
         });

--- a/test/Bucket.test.ts
+++ b/test/Bucket.test.ts
@@ -184,6 +184,37 @@ describe("Bucket", () => {
       expect(md5(actual)).toEqual(md5(bigBlob));
     });
 
+    it("should set x-reduct-content-length only for stream writes", async () => {
+      const { WritableRecord } = await import("../src/Record");
+      let lastHeaders: Record<string, string> = {};
+      const mock = {
+        post: async (_u: string, _d: unknown, h: Record<string, string>) => {
+          lastHeaders = h;
+          return { data: {}, headers: new Headers(), status: 200 };
+        },
+      };
+      const rec = (
+        data: Parameters<InstanceType<typeof WritableRecord>["write"]>[0],
+        size?: bigint,
+      ) =>
+        new WritableRecord("b", "e", { ts: 1n }, mock as any).write(data, size);
+
+      await rec("hello");
+      expect(lastHeaders["x-reduct-content-length"]).toBeUndefined();
+
+      await rec(Buffer.from("hello"));
+      expect(lastHeaders["x-reduct-content-length"]).toBeUndefined();
+
+      const stream = new ReadableStream<Uint8Array>({
+        start(c) {
+          c.enqueue(new Uint8Array([1]));
+          c.close();
+        },
+      });
+      await rec(stream, 1n);
+      expect(lastHeaders["x-reduct-content-length"]).toBe("1");
+    });
+
     it("should read write and read labels along with records", async () => {
       const bucket: Bucket = await client.getBucket("bucket");
       const record = await bucket.beginWrite("entry-1", {


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Bug fix

### What was changed?

Use `x-reduct-content-length` instead of `Content-Length` for browser compatibility with undici

### Related issues

https://github.com/reductstore/reductstore/pull/1411

### Does this PR introduce a breaking change?

No

### Other information:
