### PR TITLE
Align lifecycle SDK with olderThan and compress action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add lifecycle `compress` action support and rename lifecycle age field from `maxAge`/`max_age` to `olderThan`/`older_than` to match the ReductStore API, [PR-180](https://github.com/reductstore/reduct-js/pull/180)
 - Add lifecycle policy API support, [PR-175](https://github.com/reductstore/reduct-js/pull/175)
 
 ### Fixed

--- a/src/messages/LifecycleSettings.ts
+++ b/src/messages/LifecycleSettings.ts
@@ -13,7 +13,7 @@ export class OriginalLifecycleSettings {
   type?: LifecycleType;
   bucket = "";
   entries: string[] = [];
-  max_age = "";
+  older_than = "";
   interval?: string;
   when?: any;
   mode?: LifecycleMode;
@@ -41,7 +41,7 @@ export class LifecycleSettings {
   /**
    * Maximum record age, e.g. "30d", "24h", or "3600s".
    */
-  readonly maxAge: string = "";
+  readonly olderThan: string = "";
 
   /**
    * Interval between lifecycle runs, e.g. "10m", "1h", or "3600s".
@@ -63,7 +63,7 @@ export class LifecycleSettings {
       lifecycleType: parseLifecycleType(data.type),
       bucket: data.bucket,
       entries: data.entries,
-      maxAge: data.max_age,
+      olderThan: data.older_than,
       interval: data.interval,
       when: data.when,
       mode: parseLifecycleMode(data.mode),
@@ -75,7 +75,7 @@ export class LifecycleSettings {
       type: data.lifecycleType ?? DEFAULT_LIFECYCLE_TYPE,
       bucket: data.bucket,
       entries: data.entries,
-      max_age: data.maxAge,
+      older_than: data.olderThan,
       interval: data.interval,
       when: data.when,
       mode: data.mode ?? DEFAULT_LIFECYCLE_MODE,

--- a/src/messages/LifecycleType.ts
+++ b/src/messages/LifecycleType.ts
@@ -1,19 +1,20 @@
 /**
  * LifecycleType string literal type for TypeScript type checking.
  */
-export type LifecycleType = "delete";
+export type LifecycleType = "delete" | "compress";
 
 /**
  * LifecycleType namespace providing constant values for runtime usage.
  */
 export namespace LifecycleType {
   export const DELETE: LifecycleType = "delete";
+  export const COMPRESS: LifecycleType = "compress";
 }
 
 export const DEFAULT_LIFECYCLE_TYPE: LifecycleType = "delete";
 
 export const parseLifecycleType = (type?: string): LifecycleType => {
-  if (type === "delete") {
+  if (type === "delete" || type === "compress") {
     return type;
   }
 

--- a/test/Lifecycle.test.ts
+++ b/test/Lifecycle.test.ts
@@ -10,10 +10,10 @@ describe("Lifecycle", () => {
   const client: Client = makeClient();
 
   const settings = {
-    lifecycleType: "delete" as const,
+    lifecycleType: "compress" as const,
     bucket: "test-bucket-1",
     entries: [],
-    maxAge: "1h",
+    olderThan: "1h",
     interval: "10m",
     mode: "enabled" as const,
   };
@@ -67,10 +67,10 @@ describe("Lifecycle", () => {
     await client.createLifecycle("test-lifecycle", settings);
 
     const newSettings = {
-      lifecycleType: "delete" as const,
+      lifecycleType: "compress" as const,
       bucket: "test-bucket-1",
       entries: ["entry-1", "entry-2"],
-      maxAge: "2h",
+      olderThan: "2h",
       interval: "20m",
       when: { "&label": { $eq: "value" } },
       mode: "enabled" as const,
@@ -91,7 +91,7 @@ describe("Lifecycle", () => {
     expect(lifecycle.settings.mode).toBe("dry_run");
     expect(lifecycle.settings).toMatchObject({
       bucket: settings.bucket,
-      maxAge: settings.maxAge,
+      olderThan: settings.olderThan,
       interval: settings.interval,
     });
   });

--- a/test/Lifecycle.test.ts
+++ b/test/Lifecycle.test.ts
@@ -38,10 +38,12 @@ describe("Lifecycle", () => {
   });
 
   it_api("1.20")("should create a lifecycle policy", async () => {
-    await client.createLifecycle("test-lifecycle", {
+    const createSettings = {
       ...settings,
       lifecycleType: "compress" as const,
-    });
+    };
+
+    await client.createLifecycle("test-lifecycle", createSettings);
 
     const lifecycles = await client.getLifecycleList();
     expect(lifecycles).toHaveLength(1);
@@ -54,7 +56,7 @@ describe("Lifecycle", () => {
       isProvisioned: false,
     });
 
-    expect(lifecycle.settings).toMatchObject(settings);
+    expect(lifecycle.settings).toMatchObject(createSettings);
   });
 
   it_api("1.20")("should delete a lifecycle policy", async () => {

--- a/test/Lifecycle.test.ts
+++ b/test/Lifecycle.test.ts
@@ -10,7 +10,7 @@ describe("Lifecycle", () => {
   const client: Client = makeClient();
 
   const settings = {
-    lifecycleType: "compress" as const,
+    lifecycleType: "delete" as const,
     bucket: "test-bucket-1",
     entries: [],
     olderThan: "1h",
@@ -38,7 +38,7 @@ describe("Lifecycle", () => {
   });
 
   it_api("1.20")("should create a lifecycle policy", async () => {
-    await client.createLifecycle("test-lifecycle", settings);
+    await client.createLifecycle("test-lifecycle", { ...settings, lifecycleType: "compress" as const });
 
     const lifecycles = await client.getLifecycleList();
     expect(lifecycles).toHaveLength(1);
@@ -67,7 +67,7 @@ describe("Lifecycle", () => {
     await client.createLifecycle("test-lifecycle", settings);
 
     const newSettings = {
-      lifecycleType: "compress" as const,
+      lifecycleType: "delete" as const,
       bucket: "test-bucket-1",
       entries: ["entry-1", "entry-2"],
       olderThan: "2h",

--- a/test/Lifecycle.test.ts
+++ b/test/Lifecycle.test.ts
@@ -38,7 +38,10 @@ describe("Lifecycle", () => {
   });
 
   it_api("1.20")("should create a lifecycle policy", async () => {
-    await client.createLifecycle("test-lifecycle", { ...settings, lifecycleType: "compress" as const });
+    await client.createLifecycle("test-lifecycle", {
+      ...settings,
+      lifecycleType: "compress" as const,
+    });
 
     const lifecycles = await client.getLifecycleList();
     expect(lifecycles).toHaveLength(1);


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature update

### What was changed?

- add lifecycle `compress` action support to the JS SDK runtime/types
- rename lifecycle settings field from `maxAge`/`max_age` to `olderThan`/`older_than`
- update lifecycle integration tests to use the new field and action
- update changelog

### Related issues

- https://github.com/reductstore/reductstore/pull/1427
- https://github.com/reductstore/reductstore/pull/1429

### Does this PR introduce a breaking change?

Yes. The lifecycle API is still unreleased in this SDK, so it now uses `olderThan` instead of `maxAge` before release.

### Other information:

- Build/typecheck passes locally.
- `test/Lifecycle.test.ts` still requires a local ReductStore test server, so those integration tests cannot complete here without it.
