### PR TITLE
Add replication destination prefix support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Add replication destination prefix support, [PR-XX](https://github.com/reductstore/reduct-js/pull/XX)
+
 ## 1.20.0 - 2026-06-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add replication destination prefix support, [PR-XX](https://github.com/reductstore/reduct-js/pull/XX)
+- Add replication destination prefix support, [PR-185](https://github.com/reductstore/reduct-js/pull/185)
 
 ## 1.20.0 - 2026-06-16
 

--- a/src/messages/ReplicationSettings.ts
+++ b/src/messages/ReplicationSettings.ts
@@ -14,6 +14,7 @@ export class OriginalReplicationSettings {
   dst_host = "";
   dst_token?: string;
   entries: string[] = [];
+  dst_prefix?: string;
   when?: any;
   mode?: ReplicationMode;
 }
@@ -48,6 +49,11 @@ export class ReplicationSettings {
   readonly entries: string[] = [];
 
   /**
+   * Prefix to add to destination entry names.
+   */
+  readonly dstPrefix?: string;
+
+  /**
    * Conditional query
    */
   readonly when?: any;
@@ -64,6 +70,7 @@ export class ReplicationSettings {
       dstHost: data.dst_host,
       dstToken: data.dst_token,
       entries: data.entries,
+      dstPrefix: data.dst_prefix ?? "",
       when: data.when,
       mode: parseReplicationMode(data.mode),
     };
@@ -76,6 +83,7 @@ export class ReplicationSettings {
       dst_host: data.dstHost,
       dst_token: data.dstToken,
       entries: data.entries,
+      ...(data.dstPrefix ? { dst_prefix: data.dstPrefix } : {}),
       when: data.when,
       mode: data.mode ?? DEFAULT_REPLICATION_MODE,
     };

--- a/src/messages/ReplicationSettings.ts
+++ b/src/messages/ReplicationSettings.ts
@@ -70,7 +70,7 @@ export class ReplicationSettings {
       dstHost: data.dst_host,
       dstToken: data.dst_token,
       entries: data.entries,
-      dstPrefix: data.dst_prefix ?? "",
+      dstPrefix: data.dst_prefix,
       when: data.when,
       mode: parseReplicationMode(data.mode),
     };
@@ -83,7 +83,7 @@ export class ReplicationSettings {
       dst_host: data.dstHost,
       dst_token: data.dstToken,
       entries: data.entries,
-      ...(data.dstPrefix ? { dst_prefix: data.dstPrefix } : {}),
+      dst_prefix: data.dstPrefix,
       when: data.when,
       mode: data.mode ?? DEFAULT_REPLICATION_MODE,
     };

--- a/test/Replication.test.ts
+++ b/test/Replication.test.ts
@@ -1,57 +1,6 @@
 import { Client } from "../src/Client";
 import { cleanStorage, it_api, makeClient } from "./utils/Helpers";
 import { DiagnosticsItem } from "../src/messages/Diagnostics";
-import { ReplicationSettings } from "../src/messages/ReplicationSettings";
-
-describe("ReplicationSettings", () => {
-  const originalSettings = {
-    src_bucket: "test-bucket-1",
-    dst_bucket: "test-bucket-2",
-    dst_host: "http://localhost:8383",
-    entries: ["entry-1"],
-    mode: "enabled" as const,
-  };
-
-  it("should parse destination prefix", () => {
-    const settings = ReplicationSettings.parse({
-      ...originalSettings,
-      dst_prefix: "robot-1",
-    });
-
-    expect(settings.dstPrefix).toBe("robot-1");
-  });
-
-  it("should default missing destination prefix to empty string", () => {
-    const settings = ReplicationSettings.parse(originalSettings);
-
-    expect(settings.dstPrefix).toBe("");
-  });
-
-  it("should serialize non-empty destination prefix", () => {
-    const settings = ReplicationSettings.serialize({
-      srcBucket: "test-bucket-1",
-      dstBucket: "test-bucket-2",
-      dstHost: "http://localhost:8383",
-      entries: ["entry-1"],
-      dstPrefix: "robot-1",
-      mode: "enabled",
-    });
-
-    expect(settings.dst_prefix).toBe("robot-1");
-  });
-
-  it("should omit empty destination prefix", () => {
-    const settings = ReplicationSettings.serialize({
-      srcBucket: "test-bucket-1",
-      dstBucket: "test-bucket-2",
-      dstHost: "http://localhost:8383",
-      entries: ["entry-1"],
-      mode: "enabled",
-    });
-
-    expect(settings).not.toHaveProperty("dst_prefix");
-  });
-});
 
 describe("Replication", () => {
   const client: Client = makeClient();

--- a/test/Replication.test.ts
+++ b/test/Replication.test.ts
@@ -1,6 +1,57 @@
 import { Client } from "../src/Client";
 import { cleanStorage, it_api, makeClient } from "./utils/Helpers";
 import { DiagnosticsItem } from "../src/messages/Diagnostics";
+import { ReplicationSettings } from "../src/messages/ReplicationSettings";
+
+describe("ReplicationSettings", () => {
+  const originalSettings = {
+    src_bucket: "test-bucket-1",
+    dst_bucket: "test-bucket-2",
+    dst_host: "http://localhost:8383",
+    entries: ["entry-1"],
+    mode: "enabled" as const,
+  };
+
+  it("should parse destination prefix", () => {
+    const settings = ReplicationSettings.parse({
+      ...originalSettings,
+      dst_prefix: "robot-1",
+    });
+
+    expect(settings.dstPrefix).toBe("robot-1");
+  });
+
+  it("should default missing destination prefix to empty string", () => {
+    const settings = ReplicationSettings.parse(originalSettings);
+
+    expect(settings.dstPrefix).toBe("");
+  });
+
+  it("should serialize non-empty destination prefix", () => {
+    const settings = ReplicationSettings.serialize({
+      srcBucket: "test-bucket-1",
+      dstBucket: "test-bucket-2",
+      dstHost: "http://localhost:8383",
+      entries: ["entry-1"],
+      dstPrefix: "robot-1",
+      mode: "enabled",
+    });
+
+    expect(settings.dst_prefix).toBe("robot-1");
+  });
+
+  it("should omit empty destination prefix", () => {
+    const settings = ReplicationSettings.serialize({
+      srcBucket: "test-bucket-1",
+      dstBucket: "test-bucket-2",
+      dstHost: "http://localhost:8383",
+      entries: ["entry-1"],
+      mode: "enabled",
+    });
+
+    expect(settings).not.toHaveProperty("dst_prefix");
+  });
+});
 
 describe("Replication", () => {
   const client: Client = makeClient();
@@ -77,6 +128,27 @@ describe("Replication", () => {
     const replication = await client.getReplication("test-replication");
     expect(replication.settings).toMatchObject(newSettings);
   });
+
+  it_api("1.21")(
+    "should create and update a replication with prefix",
+    async () => {
+      await client.createReplication("test-replication-prefix", {
+        ...settings,
+        dstPrefix: "robot-1",
+      });
+
+      let replication = await client.getReplication("test-replication-prefix");
+      expect(replication.settings.dstPrefix).toBe("robot-1");
+
+      await client.updateReplication("test-replication-prefix", {
+        ...settings,
+        dstPrefix: "line-a",
+      });
+
+      replication = await client.getReplication("test-replication-prefix");
+      expect(replication.settings.dstPrefix).toBe("line-a");
+    },
+  );
 
   it_api("1.18")("should set replication mode", async () => {
     await client.createReplication("test-replication", settings);

--- a/test/utils/Helpers.ts
+++ b/test/utils/Helpers.ts
@@ -44,6 +44,10 @@ export const cleanStorage = async (client: Client): Promise<void> => {
   // Delete buckets sequentially to avoid race conditions
   const buckets = await client.getBucketList();
   for (const info of buckets) {
+    if (info.name.startsWith("$")) {
+      continue;
+    }
+
     try {
       const bucket = await client.getBucket(info.name);
       await bucket.remove();


### PR DESCRIPTION
Closes #184

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

- Added `ReplicationSettings.dstPrefix` and wire support for `settings.dst_prefix`.
- Kept create/update compatibility with older servers by omitting `dst_prefix` when `dstPrefix` is empty or unset.
- Added DTO parse/serialize coverage and a ReductStore API v1.21 replication create/update/get round-trip.
- Updated test cleanup to leave internal `$...` buckets alone, which is required for the current `reduct/store:main` server.

Validation:

- `env RS_API_TOKEN=token npm test` against `reduct/store:main`
- `env RS_API_TOKEN=token npm test` against `reduct/store:latest`
- `npm run fmt:check`
- `npm run lint`
- `npm run tsc`

### Related issues

- https://github.com/reductstore/reduct-js/issues/184
- https://github.com/reductstore/reductstore/issues/1487
- https://github.com/reductstore/reductstore/pull/1486

### Does this PR introduce a breaking change?

No. The new `dstPrefix` setting is additive, and unset/empty values are omitted from create/update payloads.

### Other information:

The issue text originally used `prefix`, but the approved plan targets the final ReductStore core API field `dst_prefix` and public TypeScript field `dstPrefix`.
