### PR TITLE
Add replication compression setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.21.0-beta.0 - 2026-07-14
+
 ### Added
 
 - Add replication compression setting support, [PR-187](https://github.com/reductstore/reduct-js/pull/187)
@@ -442,7 +444,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/reductstore/reduct-js/compare/v1.20.0...HEAD
+[Unreleased]: https://github.com/reductstore/reduct-js/compare/v1.21.0-beta.0...HEAD
+[1.21.0-beta.0]: https://github.com/reductstore/reduct-js/compare/v1.20.0...v1.21.0-beta.0
 [1.20.0]: https://github.com/reductstore/reduct-js/compare/v1.19.3...v1.20.0
 [1.19.3]: https://github.com/reductstore/reduct-js/compare/v1.19.2...v1.19.3
 [1.19.2]: https://github.com/reductstore/reduct-js/compare/v1.19.1...v1.19.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add replication compression setting support.
+- Add replication compression setting support, [PR-187](https://github.com/reductstore/reduct-js/pull/187)
 - Add replication destination prefix support, [PR-185](https://github.com/reductstore/reduct-js/pull/185)
 
 ## 1.20.0 - 2026-06-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add replication compression setting support.
 - Add replication destination prefix support, [PR-185](https://github.com/reductstore/reduct-js/pull/185)
 
 ## 1.20.0 - 2026-06-16

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reduct-js",
-  "version": "1.20.0",
+  "version": "1.21.0-beta.0",
   "description": "ReductStore Client SDK for Javascript/NodeJS/Typescript",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { Token, TokenPermissions, TokenCreateRequest } from "./messages/Token";
 import { ReplicationInfo } from "./messages/ReplicationInfo";
 import { ReplicationSettings } from "./messages/ReplicationSettings";
 import { ReplicationMode } from "./messages/ReplicationMode";
+import { ReplicationCompression } from "./messages/ReplicationCompression";
 import { FullReplicationInfo } from "./messages/ReplicationInfo";
 import { LifecycleInfo, FullLifecycleInfo } from "./messages/LifecycleInfo";
 import { LifecycleMode } from "./messages/LifecycleMode";
@@ -38,6 +39,7 @@ export {
   ReplicationInfo,
   ReplicationSettings,
   FullReplicationInfo,
+  ReplicationCompression,
   LifecycleInfo,
   LifecycleSettings,
   FullLifecycleInfo,

--- a/src/messages/ReplicationCompression.ts
+++ b/src/messages/ReplicationCompression.ts
@@ -1,0 +1,33 @@
+/**
+ * ReplicationCompression string literal type for TypeScript type checking.
+ */
+export type ReplicationCompression = "none" | "zstd" | "gzip";
+
+/**
+ * ReplicationCompression namespace providing constant values for runtime usage.
+ */
+export namespace ReplicationCompression {
+  export const NONE: ReplicationCompression = "none";
+  export const ZSTD: ReplicationCompression = "zstd";
+  export const GZIP: ReplicationCompression = "gzip";
+}
+
+export const DEFAULT_REPLICATION_COMPRESSION: ReplicationCompression = "none";
+
+export const parseReplicationCompression = (
+  compression?: string,
+): ReplicationCompression => {
+  if (compression === undefined) {
+    return DEFAULT_REPLICATION_COMPRESSION;
+  }
+
+  if (
+    compression === "none" ||
+    compression === "zstd" ||
+    compression === "gzip"
+  ) {
+    return compression;
+  }
+
+  throw new Error(`Unknown replication compression: ${compression}`);
+};

--- a/src/messages/ReplicationSettings.ts
+++ b/src/messages/ReplicationSettings.ts
@@ -7,6 +7,11 @@ import {
   parseReplicationMode,
   ReplicationMode,
 } from "./ReplicationMode";
+import {
+  DEFAULT_REPLICATION_COMPRESSION,
+  parseReplicationCompression,
+  ReplicationCompression,
+} from "./ReplicationCompression";
 
 export class OriginalReplicationSettings {
   src_bucket = "";
@@ -17,6 +22,7 @@ export class OriginalReplicationSettings {
   dst_prefix?: string;
   when?: any;
   mode?: ReplicationMode;
+  compression?: string;
 }
 
 /**
@@ -63,6 +69,11 @@ export class ReplicationSettings {
    */
   readonly mode?: ReplicationMode;
 
+  /**
+   * Wire compression for replication batch payload transfer.
+   */
+  readonly compression?: ReplicationCompression;
+
   static parse(data: OriginalReplicationSettings): ReplicationSettings {
     return {
       srcBucket: data.src_bucket,
@@ -73,6 +84,7 @@ export class ReplicationSettings {
       dstPrefix: data.dst_prefix,
       when: data.when,
       mode: parseReplicationMode(data.mode),
+      compression: parseReplicationCompression(data.compression),
     };
   }
 
@@ -86,6 +98,7 @@ export class ReplicationSettings {
       dst_prefix: data.dstPrefix,
       when: data.when,
       mode: data.mode ?? DEFAULT_REPLICATION_MODE,
+      compression: data.compression ?? DEFAULT_REPLICATION_COMPRESSION,
     };
   }
 }

--- a/test/Replication.test.ts
+++ b/test/Replication.test.ts
@@ -1,6 +1,60 @@
 import { Client } from "../src/Client";
+import { ReplicationCompression } from "../src/messages/ReplicationCompression";
+import { ReplicationSettings } from "../src/messages/ReplicationSettings";
 import { cleanStorage, it_api, makeClient } from "./utils/Helpers";
 import { DiagnosticsItem } from "../src/messages/Diagnostics";
+
+describe("ReplicationSettings", () => {
+  it("should default omitted compression to none", () => {
+    const settings = ReplicationSettings.parse({
+      src_bucket: "src",
+      dst_bucket: "dst",
+      dst_host: "http://localhost:8383",
+      entries: [],
+    });
+
+    expect(settings.compression).toBe(ReplicationCompression.NONE);
+    expect(ReplicationSettings.serialize(settings).compression).toBe(
+      ReplicationCompression.NONE,
+    );
+  });
+
+  it("should serialize replication compression", () => {
+    const payload = ReplicationSettings.serialize({
+      srcBucket: "src",
+      dstBucket: "dst",
+      dstHost: "http://localhost:8383",
+      entries: [],
+      compression: ReplicationCompression.ZSTD,
+    });
+
+    expect(payload.compression).toBe("zstd");
+  });
+
+  it("should parse replication compression", () => {
+    const settings = ReplicationSettings.parse({
+      src_bucket: "src",
+      dst_bucket: "dst",
+      dst_host: "http://localhost:8383",
+      entries: [],
+      compression: "gzip",
+    });
+
+    expect(settings.compression).toBe(ReplicationCompression.GZIP);
+  });
+
+  it("should reject unknown replication compression values", () => {
+    expect(() =>
+      ReplicationSettings.parse({
+        src_bucket: "src",
+        dst_bucket: "dst",
+        dst_host: "http://localhost:8383",
+        entries: [],
+        compression: "brotli",
+      }),
+    ).toThrow("Unknown replication compression: brotli");
+  });
+});
 
 describe("Replication", () => {
   const client: Client = makeClient();
@@ -96,6 +150,33 @@ describe("Replication", () => {
 
       replication = await client.getReplication("test-replication-prefix");
       expect(replication.settings.dstPrefix).toBe("line-a");
+    },
+  );
+
+  it_api("1.21")(
+    "should create and update a replication with compression",
+    async () => {
+      await client.createReplication("test-replication-compression", {
+        ...settings,
+        compression: ReplicationCompression.ZSTD,
+      });
+
+      let replication = await client.getReplication(
+        "test-replication-compression",
+      );
+      expect(replication.settings.compression).toBe(
+        ReplicationCompression.ZSTD,
+      );
+
+      await client.updateReplication("test-replication-compression", {
+        ...settings,
+        compression: ReplicationCompression.GZIP,
+      });
+
+      replication = await client.getReplication("test-replication-compression");
+      expect(replication.settings.compression).toBe(
+        ReplicationCompression.GZIP,
+      );
     },
   );
 


### PR DESCRIPTION
Closes #186

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

- Added a `ReplicationCompression` string-literal type and runtime namespace with `NONE`, `ZSTD`, and `GZIP` constants.
- Added `compression` to `ReplicationSettings` parse/serialize flow so create/update payloads can send `none`, `zstd`, or `gzip`, and readbacks expose the setting.
- Exported `ReplicationCompression` from the package entrypoint.
- Added DTO tests for defaulting, serialization, parsing, and unknown-value rejection.
- Added API-gated replication integration coverage for creating and updating a replication with compression on API 1.21+.
- Updated `CHANGELOG.md` under `Unreleased / Added`. README/examples were not changed because the issue did not request them and `AGENTS.md` says not to add examples unless explicitly requested.

Validation:

- `npm test` against `reduct/store:main`: 6 files passed, 1 skipped; 105 tests passed, 6 skipped.
- `npm test` against `reduct/store:latest`: 6 files passed, 1 skipped; 105 tests passed, 6 skipped.
- `npm run fmt:check`
- `npm run lint`
- `npm run tsc`

### Related issues

- https://github.com/reductstore/reduct-js/issues/186
- Parent rollout: https://github.com/reductstore/reductstore/issues/1547
- Core implementation: https://github.com/reductstore/reductstore/pull/1538
- Original feature request: https://github.com/reductstore/reductstore/issues/1348
- Approved implementation plan: https://github.com/reductstore/reduct-js/issues/186#issuecomment-4969819385

### Does this PR introduce a breaking change?

No. This is additive: existing replication settings remain valid, omitted compression defaults to `none`, and older server responses without `settings.compression` parse as `none`.

### Other information:

Reviewers/code owners: @reductstore/maintainers @atimin

Unknown server-returned compression values throw during parsing so unsupported wire values are surfaced instead of silently becoming `none`.
