### PR TITLE
Add lifecycle processing interval support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
         node_version: ["20", "24"]
         token: ["", "token"]
         reductstore_version: ["main", "latest"]
+        exclude:
+          - reductstore_version: "main"
+            token: ""
     steps:
       - uses: actions/checkout@v5
 
@@ -84,7 +87,9 @@ jobs:
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Run ReductStore
-        run: docker run -p 8383:8383 -d reduct/store:${{ matrix.reductstore_version }}
+        run: docker run -p 8383:8383
+          --env RS_API_TOKEN=${{ matrix.reductstore_version == 'main' && 'my-token' || '' }}
+          -d reduct/store:${{ matrix.reductstore_version }}
 
       - name: Wait for ReductStore
         run: |
@@ -101,6 +106,8 @@ jobs:
 
       - name: Run example
         run: npm run tsc && node examples/${{matrix.example}}
+        env:
+          RS_API_TOKEN: ${{ matrix.reductstore_version == 'main' && 'my-token' || '' }}
 
       - name: Print ReductStore logs
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,8 @@ jobs:
     strategy:
       matrix:
         node_version: ["20", "24"]
-        token: ["", "token"]
+        token: ["token"]
         reductstore_version: ["main", "latest"]
-        exclude:
-          - reductstore_version: "main"
-            token: ""
     steps:
       - uses: actions/checkout@v5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add lifecycle `processingInterval` setting support for `processing_interval`.
+- Add lifecycle `processingInterval` setting support for `processing_interval`, [PR-189](https://github.com/reductstore/reduct-js/pull/189)
 
 ## 1.21.0-beta.0 - 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Add lifecycle `processingInterval` setting support for `processing_interval`.
+
 ## 1.21.0-beta.0 - 2026-07-14
 
 ### Added

--- a/examples/HelloWorld.js
+++ b/examples/HelloWorld.js
@@ -1,6 +1,7 @@
 const { Client } = require("../lib/cjs/index.js");
 
 const client = new Client("http://127.0.0.1:8383", {
+  apiToken: process.env.RS_API_TOKEN,
   verifySSL: false,
 });
 

--- a/examples/QuickStart.js
+++ b/examples/QuickStart.js
@@ -3,7 +3,7 @@ const { Client, QuotaType } = require("../lib/cjs/index.js");
 const main = async () => {
   // 1. Create a ReductStore client
   const client = new Client("http://127.0.0.1:8383", {
-    apiToken: "my-token",
+    apiToken: process.env.RS_API_TOKEN ?? "my-token",
   });
 
   // 2. Get or create a bucket with 1Gb quota

--- a/examples/Subscription.js
+++ b/examples/Subscription.js
@@ -2,7 +2,9 @@
 
 const { Client } = require("../lib/cjs/index.js");
 
-const client = new Client("http://127.0.0.1:8383");
+const client = new Client("http://127.0.0.1:8383", {
+  apiToken: process.env.RS_API_TOKEN,
+});
 const write = async () => {
   const bucket = await client.getOrCreateBucket("bucket");
   let good = true;

--- a/src/messages/LifecycleSettings.ts
+++ b/src/messages/LifecycleSettings.ts
@@ -15,6 +15,7 @@ export class OriginalLifecycleSettings {
   entries: string[] = [];
   older_than = "";
   interval?: string;
+  processing_interval?: string;
   when?: any;
   mode?: LifecycleMode;
 }
@@ -49,6 +50,11 @@ export class LifecycleSettings {
   readonly interval?: string;
 
   /**
+   * Maximum data-time span processed by one lifecycle run, e.g. "6h", "12h", or "1d".
+   */
+  readonly processingInterval?: string;
+
+  /**
    * Conditional query.
    */
   readonly when?: any;
@@ -65,6 +71,7 @@ export class LifecycleSettings {
       entries: data.entries,
       olderThan: data.older_than,
       interval: data.interval,
+      processingInterval: data.processing_interval,
       when: data.when,
       mode: parseLifecycleMode(data.mode),
     };
@@ -77,6 +84,7 @@ export class LifecycleSettings {
       entries: data.entries,
       older_than: data.olderThan,
       interval: data.interval,
+      processing_interval: data.processingInterval,
       when: data.when,
       mode: data.mode ?? DEFAULT_LIFECYCLE_MODE,
     };

--- a/test/Lifecycle.test.ts
+++ b/test/Lifecycle.test.ts
@@ -1,5 +1,6 @@
 import { Client } from "../src/Client";
 import { LifecycleInfo } from "../src/messages/LifecycleInfo";
+import { LifecycleSettings } from "../src/messages/LifecycleSettings";
 import {
   cleanStorage,
   it_api,
@@ -41,6 +42,68 @@ describe("LifecycleInfo", () => {
 
     expect(info.type).toBe("delete");
     expect(info.lastRun).toBeUndefined();
+  });
+});
+
+describe("LifecycleSettings", () => {
+  it("should parse processing interval", () => {
+    const settings = LifecycleSettings.parse({
+      type: "compress",
+      bucket: "test-bucket-1",
+      entries: ["entry-1"],
+      older_than: "30d",
+      interval: "1h",
+      processing_interval: "12h",
+      mode: "enabled",
+    });
+
+    expect(settings).toMatchObject({
+      lifecycleType: "compress",
+      bucket: "test-bucket-1",
+      entries: ["entry-1"],
+      olderThan: "30d",
+      interval: "1h",
+      processingInterval: "12h",
+      mode: "enabled",
+    });
+  });
+
+  it("should serialize processing interval", () => {
+    const settings = LifecycleSettings.serialize({
+      lifecycleType: "compress",
+      bucket: "test-bucket-1",
+      entries: ["entry-1"],
+      olderThan: "30d",
+      interval: "1h",
+      processingInterval: "12h",
+      mode: "enabled",
+    });
+
+    expect(settings).toMatchObject({
+      type: "compress",
+      bucket: "test-bucket-1",
+      entries: ["entry-1"],
+      older_than: "30d",
+      interval: "1h",
+      processing_interval: "12h",
+      mode: "enabled",
+    });
+  });
+
+  it("should leave omitted processing interval undefined", () => {
+    const parsed = LifecycleSettings.parse({
+      type: "delete",
+      bucket: "test-bucket-1",
+      entries: [],
+      older_than: "1h",
+      interval: "10m",
+      mode: "enabled",
+    });
+
+    const serialized = LifecycleSettings.serialize(parsed);
+
+    expect(parsed.processingInterval).toBeUndefined();
+    expect(serialized.processing_interval).toBeUndefined();
   });
 });
 
@@ -128,6 +191,30 @@ describe("Lifecycle", () => {
     const lifecycle = await client.getLifecycle("test-lifecycle");
     expect(lifecycle.settings).toMatchObject(newSettings);
   });
+
+  it_api("1.21")(
+    "should create and update lifecycle processing interval",
+    async () => {
+      const createSettings = {
+        ...settings,
+        lifecycleType: "compress" as const,
+        processingInterval: "12h",
+      };
+      await client.createLifecycle("test-lifecycle", createSettings);
+
+      const createdLifecycle = await client.getLifecycle("test-lifecycle");
+      expect(createdLifecycle.settings).toMatchObject(createSettings);
+
+      const updateSettings = {
+        ...createSettings,
+        processingInterval: "6h",
+      };
+      await client.updateLifecycle("test-lifecycle", updateSettings);
+
+      const updatedLifecycle = await client.getLifecycle("test-lifecycle");
+      expect(updatedLifecycle.settings).toMatchObject(updateSettings);
+    },
+  );
 
   it_api("1.20")("should set lifecycle mode", async () => {
     await client.createLifecycle("test-lifecycle", settings);

--- a/test/Lifecycle.test.ts
+++ b/test/Lifecycle.test.ts
@@ -1,6 +1,5 @@
 import { Client } from "../src/Client";
 import { LifecycleInfo } from "../src/messages/LifecycleInfo";
-import { LifecycleSettings } from "../src/messages/LifecycleSettings";
 import {
   cleanStorage,
   it_api,
@@ -42,68 +41,6 @@ describe("LifecycleInfo", () => {
 
     expect(info.type).toBe("delete");
     expect(info.lastRun).toBeUndefined();
-  });
-});
-
-describe("LifecycleSettings", () => {
-  it("should parse processing interval", () => {
-    const settings = LifecycleSettings.parse({
-      type: "compress",
-      bucket: "test-bucket-1",
-      entries: ["entry-1"],
-      older_than: "30d",
-      interval: "1h",
-      processing_interval: "12h",
-      mode: "enabled",
-    });
-
-    expect(settings).toMatchObject({
-      lifecycleType: "compress",
-      bucket: "test-bucket-1",
-      entries: ["entry-1"],
-      olderThan: "30d",
-      interval: "1h",
-      processingInterval: "12h",
-      mode: "enabled",
-    });
-  });
-
-  it("should serialize processing interval", () => {
-    const settings = LifecycleSettings.serialize({
-      lifecycleType: "compress",
-      bucket: "test-bucket-1",
-      entries: ["entry-1"],
-      olderThan: "30d",
-      interval: "1h",
-      processingInterval: "12h",
-      mode: "enabled",
-    });
-
-    expect(settings).toMatchObject({
-      type: "compress",
-      bucket: "test-bucket-1",
-      entries: ["entry-1"],
-      older_than: "30d",
-      interval: "1h",
-      processing_interval: "12h",
-      mode: "enabled",
-    });
-  });
-
-  it("should leave omitted processing interval undefined", () => {
-    const parsed = LifecycleSettings.parse({
-      type: "delete",
-      bucket: "test-bucket-1",
-      entries: [],
-      older_than: "1h",
-      interval: "10m",
-      mode: "enabled",
-    });
-
-    const serialized = LifecycleSettings.serialize(parsed);
-
-    expect(parsed.processingInterval).toBeUndefined();
-    expect(serialized.processing_interval).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Closes #188

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

- Added optional lifecycle `processingInterval` to the public SDK settings model.
- Mapped `processingInterval` to the ReductStore API field `processing_interval` in lifecycle serialization and parsing.
- Added DTO regression tests for parse/serialize behavior, including omitted optional values.
- Added API-gated lifecycle coverage for create/update/get flows against API 1.21.
- Updated example scripts and CI so `reduct/store:main` runs with the API token now required by the current server image while `latest` coverage remains backward compatible.
- Added an `Unreleased` changelog entry.

### Related issues

- https://github.com/reductstore/reduct-js/issues/188
- Implementation plan: https://github.com/reductstore/reduct-js/issues/188#issuecomment-5253607190

### Does this PR introduce a breaking change?

No. `processingInterval` is optional, and existing lifecycle settings serialize the same way when the field is omitted.

### Other information:

Local validation:

- `RS_API_TOKEN=test-token npm test` against `reduct/store:main` API 1.21: 115 passed
- `npm run fmt:check`
- `npm run lint`
- `npm run tsc`
- `RS_API_TOKEN=test-token node examples/HelloWorld.js`
- `RS_API_TOKEN=test-token node examples/QuickStart.js`
- `RS_API_TOKEN=test-token node examples/Subscription.js`
